### PR TITLE
REFACTOR sticky footer

### DIFF
--- a/src/Content/Content.js
+++ b/src/Content/Content.js
@@ -18,8 +18,14 @@ class Content extends Component {
   }
 
   render() {
+    const style = {
+      position: 'relative',
+      paddingBottom: '100px',
+      minHeight: '100%',
+    }
+
     return (
-      <div className="Content">
+      <div className="Content" style={style}>
         <Header location={this.props.location}/>
         {this.props.children}
         <Footer />

--- a/src/Footer/Footer.js
+++ b/src/Footer/Footer.js
@@ -3,6 +3,12 @@ import Paper from 'material-ui/Paper'
 
 class Footer extends Component {
   render() {
+    const blockStyle = {
+      position: 'absolute',
+      width: '100%',
+      bottom: 0,
+    }
+
     const style = {
       padding: 40,
       textAlign: 'center',
@@ -11,7 +17,7 @@ class Footer extends Component {
       backgroundColor: this.context.muiTheme.palette.primary2Color,
     }
     return (
-      <footer>
+      <footer style={blockStyle}>
         <Paper style={style} zDepth={0}>
           <p>Fait avec ♥ par l'Incubateur de services numériques</p>
         </Paper>

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,1 @@
+html, #root { height: 100%; }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import { Router, Route, IndexRoute, browserHistory } from 'react-router'
 import injectTapEventPlugin from 'react-tap-event-plugin'
 import HarvestDetail from './Section/HarvestsSection/HarvestDetail/HarvestDetail'
+import './index.css'
 
 // Needed for onTouchTap
 // http://stackoverflow.com/a/34015469/988941


### PR DESCRIPTION
When content height is smaller than screen height, the footer is
floating in the middle of the screen in a disgracious way.

![meh](https://cloud.githubusercontent.com/assets/54562/18887065/f13ee59e-84f2-11e6-9b20-0f176824ac23.png)

Made it stick to the bottom of the page instead.

![better](https://cloud.githubusercontent.com/assets/54562/18887071/f6f650c6-84f2-11e6-957c-003c5f72a40e.png)
