### PR TITLE
Change circle ci node version to 6

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,4 +4,4 @@ general:
       - gh-pages
 machine:
   node:
-    version: 6.2.0
+    version: 6

--- a/circle.yml
+++ b/circle.yml
@@ -2,3 +2,6 @@ general:
   branches:
     ignore:
       - gh-pages
+machine:
+  node:
+    version: 6.2.0


### PR DESCRIPTION
Update Circle CI node version to fix `.includes() not a function` issue.
https://circleci.com/gh/sgmap/inspire-next/54#config/containers/0
