### PR TITLE
Use a better style for the circular loader

### DIFF
--- a/src/components/CircularProgress/CircularProgress.css
+++ b/src/components/CircularProgress/CircularProgress.css
@@ -1,42 +1,25 @@
-/* http://projects.lukehaas.me/css-loaders */
-.circularProgress,
-.circularProgress:after {
-  border-radius: 50%;
-  width: 5em;
-  height: 5em;
-}
 .circularProgress {
-  margin: 10px auto;
-  font-size: 10px;
+  border-radius: 50%;
+  width: 4em;
+  height: 4em;
+  border: .25rem solid #7ECEFD;
+  border-top-color: #2185C5;
+  animation: spin 1s infinite linear;
   position: relative;
-  text-indent: -9999em;
-  border-top: 1.1em solid rgba(255, 255, 255, 0.2);
-  border-right: 1.1em solid rgba(255, 255, 255, 0.2);
-  border-bottom: 1.1em solid rgba(255, 255, 255, 0.2);
-  border-left: 1.1em solid #2185C5;
-  -webkit-transform: translateZ(0);
-  -ms-transform: translateZ(0);
-  transform: translateZ(0);
-  -webkit-animation: load8 1.1s infinite linear;
-  animation: load8 1.1s infinite linear;
+  margin: auto;
 }
-@-webkit-keyframes load8 {
+
+@keyframes spin {
   0% {
-    -webkit-transform: rotate(0deg);
     transform: rotate(0deg);
   }
   100% {
-    -webkit-transform: rotate(360deg);
     transform: rotate(360deg);
   }
 }
-@keyframes load8 {
-  0% {
-    -webkit-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-  100% {
-    -webkit-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
+
+.sr-only {
+  position: absolute !important;
+  clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+  clip: rect(1px, 1px, 1px, 1px);
 }

--- a/src/components/CircularProgress/CircularProgress.js
+++ b/src/components/CircularProgress/CircularProgress.js
@@ -2,7 +2,7 @@ import React from 'react';
 import './CircularProgress.css';
 
 const CircularProgress = () => {
-  return <div className='circularProgress'>Loading...</div>;
+  return <div className='circularProgress'><span className="sr-only">Loading...</span></div>;
 }
 
 export default CircularProgress;


### PR DESCRIPTION
The old one used an old css trick to hide the "Loading" text: `text-indent: -9999em`, this messed the display by offsetting the screen when rotating.

This is simpler.