### PR TITLE
Widening Doughnut chart width

### DIFF
--- a/src/components/Charts/DoughnutChart/DoughnutChart.js
+++ b/src/components/Charts/DoughnutChart/DoughnutChart.js
@@ -45,7 +45,7 @@ class DoughnutChart extends Component {
         <div>
 
           <div style={styles.chart}>
-            <Doughnut className="doughnut computer" data={data} width="200" />
+            <Doughnut className="doughnut computer" data={data} width="260" />
             <DoughnutChartList data={data}/>
           </div>
 


### PR DESCRIPTION
Agrandissement de la `width` de`DoughnutChart` afin de corriger le problème d'affichage des labels.

Fix #79 