### PR TITLE
Ajouter un fond blanc aux résultats de la recherche

### DIFF
--- a/src/components/Dataset/DatasetPreview.js
+++ b/src/components/Dataset/DatasetPreview.js
@@ -2,10 +2,14 @@ import React, { Component } from 'react'
 import { Link } from 'react-router'
 import { prune } from 'underscore.string'
 import Filter from '../Filter/Filter'
+import { theme } from '../../tools'
 
 const styles = {
   preview: {
     marginBottom: '3em',
+    padding: '1em',
+    backgroundColor: '#FFF',
+    boxShadow: theme.boxShadowZ1,
   },
   filterList: {
     paddingBottom: '0.5em',


### PR DESCRIPTION
Avec tout le contenu et le markdown on comprend plus rien si on separe pas mieux les blocs