### PR TITLE
Afficher/cacher la description des datasets

### DIFF
--- a/src/components/Dataset/DatasetDescription.js
+++ b/src/components/Dataset/DatasetDescription.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import { prune } from 'underscore.string'
+import MarkdownViewer from '../Markdown/MarkdownViewer'
+import { theme } from '../../tools'
+
+const styles = {
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    marginBottom: '1em',
+  },
+  action: {
+    backgroundColor: theme.blue,
+    color: '#fff',
+    border: 'none',
+    padding: '5px 10px',
+    borderBottom: '1px solid',
+    alignSelf: 'flex-end',
+  },
+}
+
+const DatasetDescription = ({description, shortDescription, showMore}) => {
+  let action
+  if (description.length > 1000) {
+    action = <button style={styles.action} onClick={() => showMore()}>{shortDescription ? 'Afficher la suite' : 'Réduire'}</button>
+  }
+  return (
+    <div style={styles.container}>
+      <MarkdownViewer markdown={shortDescription ? prune(description, 1000) : description} />
+      {action}
+    </div>
+  )
+}
+
+export default DatasetDescription

--- a/src/components/Dataset/DatasetPreview.js
+++ b/src/components/Dataset/DatasetPreview.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import { Link } from 'react-router'
-import { prune } from 'underscore.string'
-import MarkdownViewer from '../Markdown/MarkdownViewer'
+import DatasetDescription from './DatasetDescription'
 import Filter from '../Filter/Filter'
 
 const styles = {
@@ -21,9 +20,17 @@ const styles = {
 }
 
 class DatasetPreview extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {shortDescription: true}
+  }
 
   onClick(value) {
     this.props.onClick(value)
+  }
+
+  wrapDescription() {
+    this.setState({shortDescription: !this.state.shortDescription})
   }
 
   render() {
@@ -36,7 +43,7 @@ class DatasetPreview extends Component {
           <Link to={`/datasets/${recordId}`}>{metadata.title}</Link>
         </h4>
 
-        <MarkdownViewer markdown={prune(metadata.description, 1000)} />
+        <DatasetDescription description={metadata.description} shortDescription={this.state.shortDescription} showMore={() => this.wrapDescription()} />
 
         <h4 style={styles.type}>Keyword</h4>
         <div style={styles.filterList}>


### PR DESCRIPTION
Ajout d'un bouton permettant d'afficher l'intégralité de la description des `datasets` dans `DatasetPreview`.
Si la description est déjà affiché dans son intégralité, le bouton permettra de la réduire.
Aucun bouton ne sera affiché si la description est suffisamment courte. 