### PR TITLE
Remove react-tap-event-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "react-paginate": "^2.2.3",
     "react-responsive": "^1.1.5",
     "react-router": "^2.7.0",
-    "react-tap-event-plugin": "^2.0.1",
     "underscore.string": "^3.3.4",
     "whatwg-fetch": "^2.0.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -2,14 +2,9 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { Router, Route, IndexRoute, browserHistory } from 'react-router'
 import moment from 'moment'
-import injectTapEventPlugin from 'react-tap-event-plugin'
 import HarvestDetail from './components/Harvest/HarvestDetail'
 import WrappedDatasets from './components/Dataset/WrappedDatasets'
 import './index.css'
-
-// Needed for onTouchTap
-// http://stackoverflow.com/a/34015469/988941
-injectTapEventPlugin()
 
 moment.locale('fr')
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2025,7 +2025,7 @@ faye-websocket@~0.7.3:
   dependencies:
     websocket-driver ">=0.3.6"
 
-fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.6:
+fbjs@^0.8.1, fbjs@^0.8.4:
   version "0.8.6"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.6.tgz#7eb67d6986b2d5007a9b6e92e0e7cb6f75cad290"
   dependencies:
@@ -4074,12 +4074,6 @@ react-router@^2.7.0:
     invariant "^2.2.1"
     loose-envify "^1.2.0"
     warning "^3.0.0"
-
-react-tap-event-plugin@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-tap-event-plugin/-/react-tap-event-plugin-2.0.1.tgz#316beb3bc6556e29ec869a7293e89c826a9074d2"
-  dependencies:
-    fbjs "^0.8.6"
 
 react@^15.3.1:
   version "15.4.1"


### PR DESCRIPTION
Suppression de `react-tap-event-plugin` pour des problèmes de compatibilité inter-dépendances.

Il avait pour but de permettre la compatibilité de `React` avec de "vieux" terminaux mobile et est donc jugé optionnel.