### PR TITLE
Garder les filtres actifs à chaque recherche

### DIFF
--- a/src/components/Dataset/Datasets.js
+++ b/src/components/Dataset/Datasets.js
@@ -72,7 +72,7 @@ class Datasets extends Component {
   }
 
   userSearch(textInput) {
-    const changes = { textInput, filters: [], datasets: null, offset: 0, page: 1 }
+    const changes = { textInput, datasets: null, offset: 0, page: 1 }
     this.setState(changes)
     this.search(changes)
   }

--- a/src/components/Dataset/__test__/Datasets.test.js
+++ b/src/components/Dataset/__test__/Datasets.test.js
@@ -9,16 +9,19 @@ const Datasets = require('proxyquire')('../Datasets', {
 }).default
 
 describe('<Datasets />', () => {
-  const query = {
-    textInput: 'text',
-    page: 2,
-    filters: [{name: 'filter1', value: 'value1'}],
-  }
+
+  let wrapper
+  beforeEach(() => {
+    const query = {
+      textInput: 'text',
+      page: 2,
+      filters: [{name: 'filter1', value: 'value1'}],
+    }
+    wrapper = shallow(<Datasets pathname={'pathname'} query={query} />)
+  })
 
   describe('addFilter()', () => {
     it('should add filter and reset page and offset', () => {
-      const wrapper = shallow(<Datasets pathname={'pathname'} query={query} />)
-
       wrapper.instance().addFilter({name: 'filter2', value: 'value2'})
 
       expect(wrapper.state('page')).toEqual(1)
@@ -29,8 +32,6 @@ describe('<Datasets />', () => {
 
   describe('removeFilter()', () => {
     it('should remove filter and reset page and offset', () => {
-      const wrapper = shallow(<Datasets pathname={'pathname'} query={query} />)
-
       wrapper.instance().removeFilter({name: 'filter1', value: 'value1'})
 
       expect(wrapper.state('page')).toEqual(1)
@@ -40,13 +41,12 @@ describe('<Datasets />', () => {
   })
 
   describe('userSearch()', () => {
-    it('should change textInput and reset filters, datasets, offset and page', () => {
-      const wrapper = shallow(<Datasets pathname={'pathname'} query={query} />)
-      const textInput = 'new search'
+    it('should change textInput and reset datasets, offset and page', () => {
+      const textInput = 'new seach'
       wrapper.instance().userSearch(textInput)
 
       expect(wrapper.state('textInput')).toEqual(textInput)
-      expect(wrapper.state('filters')).toEqual([])
+      expect(wrapper.state('filters')).toEqual([{name: 'filter1', value: 'value1'}])
       expect(wrapper.state('offset')).toEqual(0)
       expect(wrapper.state('page')).toEqual(1)
     })
@@ -54,6 +54,11 @@ describe('<Datasets />', () => {
 
   describe('handleChangePage()', () => {
     it('should update page and offset', () => {
+      const query = {
+        textInput: 'text',
+        page: 2,
+        filters: [{name: 'filter1', value: 'value1'}],
+      }
       const wrapper = mount(<Datasets pathname={'pathname'} query={query} />)
 
       return wrapper.instance()


### PR DESCRIPTION
Les filtres ne sont plus réinitialisés à chaque nouvelle recherche.

fix #88 Rechercher dans un catalogue