### PR TITLE
Retire le bouton "Télécharger" pour les datasets

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "webpack-dev-server": "1.16.1"
   },
   "dependencies": {
+    "chai": "^3.5.0",
+    "chai-enzyme": "^0.6.1",
     "chart.js": "^1.1.1",
     "json-loader": "^0.5.4",
     "leaflet": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "chai": "^3.5.0",
     "chai-enzyme": "^0.6.1",
     "chart.js": "^1.1.1",
+    "cheerio": "^0.22.0",
     "json-loader": "^0.5.4",
     "leaflet": "^1.0.2",
     "marked": "^0.3.6",

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -26,4 +26,8 @@ global.navigator = window.navigator = {
   platform: 'node.js',
 };
 
-global.expect = require('expect');
+var chai = require('chai')
+var chaiEnzyme = require('chai-enzyme')
+
+global.expect = chai.expect
+chai.use(chaiEnzyme())

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -12,7 +12,7 @@ var jsdom = require('jsdom').jsdom;
 
 var exposedProperties = ['window', 'navigator', 'document'];
 
-global.document = jsdom('');
+global.document = jsdom('<!doctype html><html><body></body></html>');
 global.window = document.defaultView;
 Object.keys(document.defaultView).forEach((property) => {
   if (typeof global[property] === 'undefined') {
@@ -21,8 +21,9 @@ Object.keys(document.defaultView).forEach((property) => {
   }
 });
 
-global.navigator = {
-  userAgent: 'node.js'
+global.navigator = window.navigator = {
+  userAgent: 'node.js',
+  platform: 'node.js',
 };
 
 global.expect = require('expect');

--- a/src/components/Catalog/CatalogPreview/__test__/CatalogPreview.test.js
+++ b/src/components/Catalog/CatalogPreview/__test__/CatalogPreview.test.js
@@ -15,18 +15,18 @@ describe('<CatalogPreview />', () => {
 
     it('should display the number of records', () => {
       const records = <Counter value={metrics.records.totalCount} label="Enregistrements" />
-      expect(wrapper.contains(records)).toBe(true)
+      expect(wrapper.contains(records)).to.be.true
     })
 
     it('should display the openness percent', () => {
       const open = <Percent value={ metrics.datasets.partitions['openness'].yes} label="Données ouvertes" total={metrics.datasets.totalCount} icon="unlock alternate icon" />
-      expect(wrapper.contains(open)).toBe(true)
+      expect(wrapper.contains(open)).to.be.true
     })
 
     it('should display the downloadable percent', () => {
       const download = <Percent value={ metrics.datasets.partitions['download'].yes} label="Téléchargeable" total={metrics.datasets.totalCount} icon="download" />
 
-      expect(wrapper.contains(download)).toBe(true)
+      expect(wrapper.contains(download)).to.be.true
     })
   })
 
@@ -37,7 +37,7 @@ describe('<CatalogPreview />', () => {
     })
 
     it('should render an empty div', () => {
-      expect(wrapper.html()).toEqual('<div></div>')
+      expect(wrapper.html()).to.equal('<div></div>')
     })
   })
 

--- a/src/components/Catalog/__tests__/Catalog.test.js
+++ b/src/components/Catalog/__tests__/Catalog.test.js
@@ -20,7 +20,7 @@ describe('<Catalog />', () => {
     })
 
     it('should display the name of the catalog', () => {
-      expect(wrapper.contains(catalog.name)).toBe(true)
+      expect(wrapper.contains(catalog.name)).to.be.true
     })
 
     it('should display <CatalogPreview />', () => {
@@ -31,7 +31,7 @@ describe('<Catalog />', () => {
         .instance()
         .componentWillMount()
         .then(() => {
-          expect(wrapper.containsMatchingElement(catalogPreview)).toBe(true)
+          expect(wrapper.containsMatchingElement(catalogPreview)).to.be.true
         })
     })
 
@@ -44,14 +44,14 @@ describe('<Catalog />', () => {
       return wrapper
         .instance()
         .componentWillMount()
-        .then(() => expect(wrapper.state('metrics')).toEqual(metrics))
+        .then(() => expect(wrapper.state('metrics')).to.equal(metrics))
     })
 
     it('should display a loading', () => {
       const loader = mount(<Loader component={<div></div>} value={undefined} />)
       const wrapper = mount(<Catalog catalog={catalog} />)
 
-      expect(wrapper.html()).toContain(loader.html())
+      expect(wrapper.html()).to.contain(loader.html())
     })
   })
 

--- a/src/components/CatalogDetail/__test__/CatalogDetail.test.js
+++ b/src/components/CatalogDetail/__test__/CatalogDetail.test.js
@@ -17,7 +17,7 @@ describe('<CatalogDetail />', () => {
       const wrapper = shallow(<CatalogDetail params={{catalogId: '1'}} />)
 
       wrapper.setState({catalog, metrics})
-      expect(wrapper.find('#catalog-detail').length).toEqual(1)
+      expect(wrapper.find('#catalog-detail').length).to.equal(1)
     })
   })
 
@@ -30,7 +30,7 @@ describe('<CatalogDetail />', () => {
         return wrapper
           .instance()
           .updateMetrics()
-          .then(() => expect(wrapper.state('metrics')).toEqual(metrics))
+          .then(() => expect(wrapper.state('metrics')).to.equal(metrics))
       })
 
       it('Should add an error to this.state, catalogId is required', () => {
@@ -39,7 +39,7 @@ describe('<CatalogDetail />', () => {
         return wrapper
           .instance()
           .updateMetrics()
-          .then(() => expect(wrapper.state('errors')).toContain('catalogId is required'))
+          .then(() => expect(wrapper.state('errors')).to.contain('catalogId is required'))
       })
 
       it('Should add an error to this.state, metrics not found', () => {
@@ -48,7 +48,7 @@ describe('<CatalogDetail />', () => {
         return wrapper
           .instance()
           .updateMetrics()
-          .then(() => expect(wrapper.state('errors')).toContain('metrics not found'))
+          .then(() => expect(wrapper.state('errors')).to.contain('metrics not found'))
       })
     })
 
@@ -58,7 +58,7 @@ describe('<CatalogDetail />', () => {
         return wrapper
           .instance()
           .updateCatalog()
-          .then(() => expect(wrapper.state('catalog')).toEqual(catalog))
+          .then(() => expect(wrapper.state('catalog')).to.equal(catalog))
       })
 
       it('Should add an error to this.state, catalogId is required', () => {
@@ -67,7 +67,7 @@ describe('<CatalogDetail />', () => {
         return wrapper
           .instance()
           .updateCatalog()
-          .then(() => expect(wrapper.state('errors')).toContain('catalogId is required'))
+          .then(() => expect(wrapper.state('errors')).to.contain('catalogId is required'))
       })
 
       it('Should add an error to this.state, catalog not found', () => {
@@ -76,7 +76,7 @@ describe('<CatalogDetail />', () => {
         return wrapper
           .instance()
           .updateCatalog()
-          .then(() => expect(wrapper.state('errors')).toContain('catalog not found'))
+          .then(() => expect(wrapper.state('errors')).to.contain('catalog not found'))
       })
     })
 
@@ -87,9 +87,9 @@ describe('<CatalogDetail />', () => {
           .instance()
           .componentWillMount()
           .then(() => {
-            expect(wrapper.state('metrics')).toEqual(metrics)
-            expect(wrapper.state('catalog')).toEqual(catalog)
-            expect(wrapper.state('errors')).toEqual([])
+            expect(wrapper.state('metrics')).to.deep.equal(metrics)
+            expect(wrapper.state('catalog')).to.deep.equal(catalog)
+            expect(wrapper.state('errors')).to.deep.equal([])
           })
       })
     })
@@ -97,7 +97,7 @@ describe('<CatalogDetail />', () => {
     it('should render a loader when no catalog is fetch', () => {
       const loader = <ContentLoader />
       const wrapper = shallow(<CatalogDetail params={{catalogId: '0'}} />)
-      expect(wrapper.containsMatchingElement(loader)).toBe(true)
+      expect(wrapper.containsMatchingElement(loader)).to.be.true
     })
   })
 

--- a/src/components/Catalogs/__test__/Catalogs.test.js
+++ b/src/components/Catalogs/__test__/Catalogs.test.js
@@ -16,13 +16,13 @@ describe('<Catalogs />', () => {
       return wrapper
         .instance()
         .componentWillMount()
-        .then(() => expect(wrapper.state('catalogs')).toEqual(catalogs))
+        .then(() => expect(wrapper.state('catalogs')).to.equal(catalogs))
     })
   })
 
   it('should render a loader when no catalog is fetch', () => {
     const loader = <ContentLoader />
     const wrapper = shallow(<Catalogs />)
-    expect(wrapper.containsMatchingElement(loader)).toBe(true)
+    expect(wrapper.containsMatchingElement(loader)).to.be.true
   })
 })

--- a/src/components/Charts/DoughnutChart/__test__/DoughnutChart.test.js
+++ b/src/components/Charts/DoughnutChart/__test__/DoughnutChart.test.js
@@ -12,17 +12,17 @@ describe('<DoughnutChart />', () => {
   describe('setColor', () => {
     it('Should return a color by index', () => {
       Object.keys(colors).map( color =>
-        expect(wrapper.instance().setColor(color)).toEqual(colors[color]))
+        expect(wrapper.instance().setColor(color)).to.deep.equal(colors[color]))
     });
 
     it('Should grey color when out range', () => {
-      expect(wrapper.instance().setColor(colors.length + 1)).toEqual({name: 'grey', value: '#767676'})
+      expect(wrapper.instance().setColor(colors.length + 1)).to.deep.equal({name: 'grey', value: '#767676'})
     });
   })
 
   describe('formatData', () => {
     it('Should return formated data', () => {
-      expect(wrapper.instance().formatData(data)).toEqual(formatedData)
+      expect(wrapper.instance().formatData(data)).to.deep.equal(formatedData)
     })
 
     it('Should sort the data in ascending order', () => {
@@ -32,7 +32,7 @@ describe('<DoughnutChart />', () => {
         dataset: 427
       }
 
-      expect(wrapper.instance().formatData(descendingData)).toEqual(formatedData)
+      expect(wrapper.instance().formatData(descendingData)).to.deep.equal(formatedData)
     })
   })
 
@@ -42,14 +42,14 @@ describe('<DoughnutChart />', () => {
       const twoDataWrapper = shallow(<DoughnutChart data={{'dataset': 427}} />)
       const percent = <Percent value={100} total={100} label={formatedData[0].label} icon="database icon" />
 
-      expect(twoDataWrapper.containsMatchingElement(percent)).toEqual(true);
+      expect(twoDataWrapper.containsMatchingElement(percent)).to.deep.equal(true);
     });
 
     it('Should render Percent component when no data', () => {
       const noDataWrapper = shallow(<DoughnutChart data={{}} />)
       const noData = <h1>Aucune donnée</h1>
 
-      expect(noDataWrapper.contains(noData)).toEqual(true);
+      expect(noDataWrapper.contains(noData)).to.deep.equal(true);
     });
   })
 })

--- a/src/components/Charts/Histogram/__test__/Histogram.test.js
+++ b/src/components/Charts/Histogram/__test__/Histogram.test.js
@@ -21,7 +21,7 @@ describe('<Histogram />', () => {
       ]
     }
 
-    expect(wrapper.instance().formatData(data)).toEqual(formatedData)
+    expect(wrapper.instance().formatData(data)).to.deep.equal(formatedData)
   })
 
   it('Should throw an error', (done) => {
@@ -29,7 +29,7 @@ describe('<Histogram />', () => {
       shallow(<Histogram data={data} height={height} width={width}/>)
     }
     catch(err) {
-      expect(err).toEqual(new Error('chartType props must be Bar or Line'));
+      expect(err).to.deep.equal(new Error('chartType props must be Bar or Line'));
     }
     done();
   })
@@ -38,13 +38,13 @@ describe('<Histogram />', () => {
     const wrapper = shallow(<Histogram chartType={Line} data={data} height={height} width={width}/>)
     const chart = <Line data={wrapper.instance().formatData(data)} height={height} width={width}/>
 
-    expect(wrapper.contains(chart)).toEqual(true)
+    expect(wrapper.contains(chart)).to.deep.equal(true)
   })
 
   it('Should render a Bar component', () => {
     const wrapper = shallow(<Histogram chartType={Bar} data={data} height={height} width={width}/>)
     const chart = <Bar data={wrapper.instance().formatData(data)} height={height} width={width}/>
 
-    expect(wrapper.contains(chart)).toEqual(true)
+    expect(wrapper.contains(chart)).to.deep.equal(true)
   })
 })

--- a/src/components/Checks/__test__/CheckDataAvailability.test.js
+++ b/src/components/Checks/__test__/CheckDataAvailability.test.js
@@ -10,9 +10,9 @@ describe('<DatasetDataAvailability />', () => {
 
       const result = wrapper.instance().check()
 
-      expect(result.msg).toEqual('Au moins une des distribution est disponible.')
-      expect(result.content).toExist()
-      expect(result.valid).toEqual(true)
+      expect(result.msg).to.equal('Au moins une des distribution est disponible.')
+      expect(result.content).to.exist
+      expect(result.valid).to.be.true
     })
 
     it('should return false when the array contains no elements whith available at true', () => {
@@ -21,9 +21,9 @@ describe('<DatasetDataAvailability />', () => {
 
       const result = wrapper.instance().check()
 
-      expect(result.msg).toEqual('Aucune distribution n\'a été trouvée.')
-      expect(result.content).toBe(undefined)
-      expect(result.valid).toEqual(false)
+      expect(result.msg).to.equal('Aucune distribution n\'a été trouvée.')
+      expect(result.content).to.equal(undefined)
+      expect(result.valid).to.equal(false)
     })
 
     it('should return false when the array is empty', () => {
@@ -32,9 +32,9 @@ describe('<DatasetDataAvailability />', () => {
 
       const result = wrapper.instance().check()
 
-      expect(result.msg).toEqual('Aucune distribution n\'a été trouvée.')
-      expect(result.content).toBe(undefined)
-      expect(result.valid).toEqual(false)
+      expect(result.msg).to.equal('Aucune distribution n\'a été trouvée.')
+      expect(result.content).to.equal(undefined)
+      expect(result.valid).to.equal(false)
     })
 
     it('should return false when the array is undefined', () => {
@@ -42,9 +42,9 @@ describe('<DatasetDataAvailability />', () => {
 
       const result = wrapper.instance().check()
 
-      expect(result.msg).toEqual('Aucune distribution n\'a été trouvée.')
-      expect(result.content).toBe(undefined)
-      expect(result.valid).toEqual(false)
+      expect(result.msg).to.equal('Aucune distribution n\'a été trouvée.')
+      expect(result.content).to.equal(undefined)
+      expect(result.valid).to.equal(false)
     })
   })
 })

--- a/src/components/Checks/__test__/CheckLicense.test.js
+++ b/src/components/Checks/__test__/CheckLicense.test.js
@@ -9,9 +9,9 @@ describe('<CheckLicense />', () => {
         const wrapper = shallow(<CheckLicense license={license} />)
         const check = wrapper.instance().check()
 
-        expect(check.msg).toEqual(`La licence ${license} est valide.`)
-        expect(check.valid).toBe(true)
-        expect(check.content).toBe(undefined)
+        expect(check.msg).to.equal(`La licence ${license} est valide.`)
+        expect(check.valid).to.be.true
+        expect(check.content).to.equal(undefined)
         return true
       })
     })
@@ -22,9 +22,9 @@ describe('<CheckLicense />', () => {
 
       const check = wrapper.instance().check()
 
-      expect(check.msg).toEqual('La licence unk-license n\'est pas reconnue.')
-      expect(check.valid).toBe(false)
-      expect(check.content).toExist()
+      expect(check.msg).to.equal('La licence unk-license n\'est pas reconnue.')
+      expect(check.valid).to.equal(false)
+      expect(check.content).to.exist
     })
 
     it('should be false when license is undefined and specify the error', () => {
@@ -32,9 +32,9 @@ describe('<CheckLicense />', () => {
 
       const check = wrapper.instance().check()
 
-      expect(check.msg).toEqual('Aucune licence n\'a pu être trouvée.')
-      expect(check.valid).toBe(false)
-      expect(check.content).toExist()
+      expect(check.msg).to.equal('Aucune licence n\'a pu être trouvée.')
+      expect(check.valid).to.equal(false)
+      expect(check.content).to.exist
     })
   })
 })

--- a/src/components/Checks/__test__/CheckProducers.test.js
+++ b/src/components/Checks/__test__/CheckProducers.test.js
@@ -10,7 +10,7 @@ describe('<DatasetProducers />', () => {
 
       const result = wrapper.instance().check()
 
-      expect(result).toEqual({
+      expect(result).to.deep.equal({
         msg: 'Au moins un producteur est identifié.',
         valid: true})
     })
@@ -21,7 +21,7 @@ describe('<DatasetProducers />', () => {
 
       const result = wrapper.instance().check()
 
-      expect(result).toEqual({
+      expect(result).to.deep.equal({
         msg: 'Le producteur n\'a pas été identifié.',
         valid: false})
     })
@@ -31,7 +31,7 @@ describe('<DatasetProducers />', () => {
 
       const result = wrapper.instance().check({msg: '', content: {}, valid: false})
 
-      expect(result).toEqual({
+      expect(result).to.deep.equal({
         msg: 'Le producteur n\'a pas été identifié.',
         valid: false})
     })

--- a/src/components/Dataset/__test__/DatasetDetail.test.js
+++ b/src/components/Dataset/__test__/DatasetDetail.test.js
@@ -13,7 +13,7 @@ describe('<DatasetDetail />', () => {
     it('should display a <CircularProgress />', () => {
       const wrapper = mount(<DatasetDetail params={{ datasetId: '1' }} />)
       const progress = <CircularProgress />
-      expect(wrapper.containsMatchingElement(progress)).toBe(true)
+      expect(wrapper.containsMatchingElement(progress)).to.be.true
     })
   })
 
@@ -25,7 +25,7 @@ describe('<DatasetDetail />', () => {
         .componentWillMount()
         .then(() => {
           const titleBlock = <h1>{datasetMock.metadata.title}</h1>
-          expect(wrapper.containsMatchingElement(titleBlock)).toBe(true)
+          expect(wrapper.containsMatchingElement(titleBlock)).to.be.true
         })
     })
   })

--- a/src/components/Dataset/__test__/DatasetSection.test.js
+++ b/src/components/Dataset/__test__/DatasetSection.test.js
@@ -15,31 +15,31 @@ describe('<DatasetSection />', () => {
     })
 
     it('should display dataset title', () => {
-      expect(wrapper.contains(datasetMock.metadata.title)).toBe(true)
+      expect(wrapper.contains(datasetMock.metadata.title)).to.be.true
     })
 
     it('should display dataset description', () => {
-      expect(wrapper.contains(<MarkdownViewer markdown={datasetMock.metadata.description} />)).toBe(true)
+      expect(wrapper.contains(<MarkdownViewer markdown={datasetMock.metadata.description} />)).to.be.true
     })
 
     it('should display dataset type', () => {
-      expect(wrapper.contains(datasetMock.metadata.type)).toBe(true)
+      expect(wrapper.contains(datasetMock.metadata.type)).to.be.true
     })
 
     it('should display dataset license', () => {
-      expect(wrapper.contains(datasetMock.metadata.license)).toBe(true)
+      expect(wrapper.contains(datasetMock.metadata.license)).to.be.true
     })
 
     it('should display dataset revision date', () => {
-      expect(wrapper.contains(doneSince(datasetMock.revisionDate))).toBe(true)
+      expect(wrapper.contains(doneSince(datasetMock.revisionDate))).to.be.true
     })
 
     it('should display lineage', () => {
-      expect(wrapper.contains(datasetMock.metadata.lineage)).toBe(true)
+      expect(wrapper.contains(datasetMock.metadata.lineage)).to.be.true
     })
 
     it('should display dataset id', () => {
-      expect(wrapper.contains(datasetMock.metadata.id)).toBe(true)
+      expect(wrapper.contains(datasetMock.metadata.id)).to.be.true
     })
   })
 
@@ -53,11 +53,11 @@ describe('<DatasetSection />', () => {
     })
 
     it('should display dataset type', () => {
-      expect(wrapper.contains('inconnu')).toBe(true)
+      expect(wrapper.contains('inconnu')).to.be.true
     })
 
     it('should display dataset license', () => {
-      expect(wrapper.contains('non déterminé')).toBe(true)
+      expect(wrapper.contains('non déterminé')).to.be.true
     })
   })
 

--- a/src/components/Dataset/__test__/Datasets.test.js
+++ b/src/components/Dataset/__test__/Datasets.test.js
@@ -24,9 +24,9 @@ describe('<Datasets />', () => {
     it('should add filter and reset page and offset', () => {
       wrapper.instance().addFilter({name: 'filter2', value: 'value2'})
 
-      expect(wrapper.state('page')).toEqual(1)
-      expect(wrapper.state('offset')).toEqual(0)
-      expect(wrapper.state('filters')).toEqual([{name: 'filter1', value: 'value1'}, {name: 'filter2', value: 'value2'}])
+      expect(wrapper.state('page')).to.equal(1)
+      expect(wrapper.state('offset')).to.equal(0)
+      expect(wrapper.state('filters')).to.deep.equal([{name: 'filter1', value: 'value1'}, {name: 'filter2', value: 'value2'}])
     })
   })
 
@@ -34,9 +34,9 @@ describe('<Datasets />', () => {
     it('should remove filter and reset page and offset', () => {
       wrapper.instance().removeFilter({name: 'filter1', value: 'value1'})
 
-      expect(wrapper.state('page')).toEqual(1)
-      expect(wrapper.state('offset')).toEqual(0)
-      expect(wrapper.state('filters')).toEqual([])
+      expect(wrapper.state('page')).to.equal(1)
+      expect(wrapper.state('offset')).to.equal(0)
+      expect(wrapper.state('filters')).to.deep.equal([])
     })
   })
 
@@ -45,10 +45,10 @@ describe('<Datasets />', () => {
       const textInput = 'new seach'
       wrapper.instance().userSearch(textInput)
 
-      expect(wrapper.state('textInput')).toEqual(textInput)
-      expect(wrapper.state('filters')).toEqual([{name: 'filter1', value: 'value1'}])
-      expect(wrapper.state('offset')).toEqual(0)
-      expect(wrapper.state('page')).toEqual(1)
+      expect(wrapper.state('textInput')).to.deep.equal(textInput)
+      expect(wrapper.state('filters')).to.deep.equal([{name: 'filter1', value: 'value1'}])
+      expect(wrapper.state('offset')).to.equal(0)
+      expect(wrapper.state('page')).to.equal(1)
     })
   })
 
@@ -65,8 +65,8 @@ describe('<Datasets />', () => {
         .componentWillMount()
         .then(() => {
           wrapper.instance().handleChangePage({selected: 0})
-          expect(wrapper.state('offset')).toEqual(0)
-          expect(wrapper.state('page')).toEqual(1)
+          expect(wrapper.state('offset')).to.equal(0)
+          expect(wrapper.state('page')).to.equal(1)
         })
     })
   })

--- a/src/components/Dataset/__test__/urlParser.test.js
+++ b/src/components/Dataset/__test__/urlParser.test.js
@@ -9,7 +9,7 @@ describe('_extractFilters', () => {
     ]
     const extractedFilters = _extractFilters(qs)
 
-    expect(extractedFilters).toEqual(filters)
+    expect(extractedFilters).to.deep.equal(filters)
   })
 
   it('should return only allowed filters', () => {
@@ -19,7 +19,7 @@ describe('_extractFilters', () => {
     ]
     const extractedFilters = _extractFilters(qs)
 
-    expect(extractedFilters).toEqual(filters)
+    expect(extractedFilters).to.deep.equal(filters)
   })
 
   it('should create one items for each value', () => {
@@ -30,7 +30,7 @@ describe('_extractFilters', () => {
     ]
     const extractedFilters = _extractFilters(qs)
 
-    expect(extractedFilters).toEqual(filters)
+    expect(extractedFilters).to.deep.equal(filters)
   })
 })
 
@@ -39,7 +39,7 @@ describe('parseQuery', () => {
     const query = 'q=42&page=2&keyword=keyword1&keyword=keyword2&organization=foo'
     const result = parseQuery(query)
 
-    expect(result).toEqual(
+    expect(result).to.deep.equal(
       {
         textInput: '42',
         page: '2',

--- a/src/components/Downloads/Download.js
+++ b/src/components/Downloads/Download.js
@@ -5,22 +5,18 @@ import './Download.css'
 
 const styles = {
   active: {
-    marginRight: '5px',
     padding: '5px 10px',
     backgroundColor: theme.blue,
     color: '#fff',
     border: 'none',
   },
-  disabled: {
+  inactive: {
     marginRight: '5px',
     padding: '5px 10px',
     backgroundColor: '#ddd',
     color: '#000',
     border: 'none',
   },
-  buttons: {
-    display: 'flex',
-  }
 }
 
 const Download = ({distribution, dlFormat, isPreview, preview, style}) => {
@@ -37,23 +33,18 @@ const Download = ({distribution, dlFormat, isPreview, preview, style}) => {
     link += `services/${distribution.service}/feature-types/${distribution.typeName}/download`
   }
 
-  let downloadButton = <div style={styles.disabled}>Indisponible</div>
-  let previewButton = null
+  const name = layerName || distribution.typeName
 
   if (distribution.available) {
-    downloadButton = <a href={link + `?format=${format}&projection=${projection}`} style={styles.active}>Télécharger</a>
-    previewButton = <button style={isPreview ? styles.active : styles.disabled} onClick={() => preview && preview({distribution: distribution, link})}>Visualiser</button>
-  }
-
-  return (
-    <div style={style} className="download">
-      <a href={link}>{layerName || distribution.typeName}</a>
-      <div style={styles.buttons}>
-        {downloadButton}
-        {previewButton}
+    return (
+      <div style={style}>
+        <a href={link  + `?format=${format}&projection=${projection}`}>{name}</a>
+        <button style={isPreview ? styles.active : styles.inactive} onClick={() => preview && preview({distribution: distribution, link})}>Visualiser</button>
       </div>
-    </div>
-  )
+    )
+  } else {
+    return <div style={style}>{name}</div>
+  }
 }
 
 export default Download

--- a/src/components/Downloads/Download.js
+++ b/src/components/Downloads/Download.js
@@ -11,7 +11,6 @@ const styles = {
     border: 'none',
   },
   inactive: {
-    marginRight: '5px',
     padding: '5px 10px',
     backgroundColor: '#ddd',
     color: '#000',

--- a/src/components/Downloads/__test__/Download.test.js
+++ b/src/components/Downloads/__test__/Download.test.js
@@ -6,7 +6,7 @@ const featureType = {
   'type': 'wfs-featureType',
   'service': '556c6066330f1fcd48338831',
   'typeName': 'drac:bretagne_immeuble_mh',
-  'available': false,
+  'available': true,
   '_id': '582e1ac513e286e23b67849a'
 }
 
@@ -24,35 +24,33 @@ const format = {label: 'GeoJSON', format: 'GeoJSON', projection: 'WGS42'}
 
 describe('<Download />', () => {
 
-  describe('featureType', () => {
-    it('should create a link to a wfs-featureType dataset type', () => {
-      const link = <a href='https://inspire.data.gouv.fr/api/geogw/services/556c6066330f1fcd48338831/feature-types/drac:bretagne_immeuble_mh/download'>{'drac:bretagne_immeuble_mh'}</a>
-      const wrapper = shallow(<Download distribution={featureType} dlFormat={format}/>)
-      expect(wrapper.containsMatchingElement(link)).toBe(true)
-    })
-  })
-
-  describe('file-package', () => {
-    it('should create a link to a file-package dataset type', () => {
-      const link = <a href='https://inspire.data.gouv.fr/api/geogw/file-packages/e2880991300be9f2f4aa9f8bbcd629ea94501a72/N_AC1_GENERATEUR_SUP_S_032.TAB/download'>{'N_AC1_GENERATEUR_SUP_S_032.TAB'}</a>
-      const wrapper = shallow(<Download distribution={filePackage} dlFormat={format}/>)
-      expect(wrapper.containsMatchingElement(link)).toBe(true)
-    })
-  })
-
   describe('Available dataset', () => {
-    it('should create a link to download the dataset', () => {
-      const link = <a href='https://inspire.data.gouv.fr/api/geogw/file-packages/e2880991300be9f2f4aa9f8bbcd629ea94501a72/N_AC1_GENERATEUR_SUP_S_032.TAB/download?format=GeoJSON&projection=WGS42'>Télécharger</a>
-      const wrapper = shallow(<Download distribution={filePackage} dlFormat={format}/>)
-      expect(wrapper.containsMatchingElement(link)).toBe(true)
+
+  describe('featureType', () => {
+    it('should create a link to download wfs-featureType dataset type', () => {
+      const link = <a href='https://inspire.data.gouv.fr/api/geogw/services/556c6066330f1fcd48338831/feature-types/drac:bretagne_immeuble_mh/download?format=GeoJSON&amp;projection=WGS42'>drac:bretagne_immeuble_mh</a>
+      const wrapper = shallow(<Download distribution={featureType} dlFormat={format}/>)
+      expect(wrapper).to.contain(link)
     })
   })
+
+    describe('file-package', () => {
+      it('should create a link to download file-package dataset type', () => {
+        const link = <a href='https://inspire.data.gouv.fr/api/geogw/file-packages/e2880991300be9f2f4aa9f8bbcd629ea94501a72/N_AC1_GENERATEUR_SUP_S_032.TAB/download?format=GeoJSON&amp;projection=WGS42'>N_AC1_GENERATEUR_SUP_S_032.TAB</a>
+        const wrapper = shallow(<Download distribution={filePackage} dlFormat={format}/>)
+        expect(wrapper).to.contain(link)
+      })
+    })
+  })
+
 
   describe('Unavailable dataset', () => {
-    it('should display a disabled download button', () => {
-      const div = <div>Indisponible</div>
-      const wrapper = shallow(<Download distribution={featureType} dlFormat={format}/>)
-      expect(wrapper.containsMatchingElement(div)).toBe(true)
+    it('should display only dataset name', () => {
+      let dataset = featureType
+      dataset.available = false
+      const div = <div style={{}}>drac:bretagne_immeuble_mh</div>
+      const wrapper = shallow(<Download distribution={featureType} dlFormat={format} style={{}}/>)
+      expect(wrapper).to.contain(div)
     })
   })
 

--- a/src/components/Harvest/__test__/HarvestContent.test.js
+++ b/src/components/Harvest/__test__/HarvestContent.test.js
@@ -9,12 +9,12 @@ describe('<HarvestContent />', () => {
 
   it('should render HarvestResults component', () => {
     const wrapper = shallow(<HarvestContent successful={true} logs={harvests[0].log} />)
-    expect(wrapper.containsMatchingElement(<HarvestResults />)).toBe(true)
+    expect(wrapper.containsMatchingElement(<HarvestResults />)).to.be.true
   })
 
   it('should render HarvestLogs component', () => {
     const wrapper = shallow(<HarvestContent successful={false} logs={harvests[1].log} />)
-    expect(wrapper.containsMatchingElement(<HarvestLogs />)).toBe(true)
+    expect(wrapper.containsMatchingElement(<HarvestLogs />)).to.be.true
   })
 
 })

--- a/src/components/HarvestsTable/__test__/HarvestRow.test.js
+++ b/src/components/HarvestsTable/__test__/HarvestRow.test.js
@@ -14,15 +14,15 @@ describe('<HarvestRow />', () => {
 
   describe('doneSince', () => {
     it('Should return the time elapsed since the date sent', () => {
-      expect(doneSince(new Date())).toEqual('a few seconds ago')
+      expect(doneSince(new Date())).to.equal('a few seconds ago')
     })
 
     it('Should return N/A when no endTime ', () => {
-      expect(doneSince()).toEqual('N/A')
+      expect(doneSince()).to.equal('N/A')
     })
 
     it('Should return N/A when invalid date ', () => {
-      expect(doneSince('thisIsNotADate')).toEqual('N/A')
+      expect(doneSince('thisIsNotADate')).to.equal('N/A')
     })
   })
 
@@ -30,13 +30,13 @@ describe('<HarvestRow />', () => {
     it('Should display successful text', () => {
       const text = <div>Réussi</div>
       const wrapper = shallow(<HarvestRow harvest={harvestSuccessed} previousHarvest={harvestSuccessed} catalog={catalog} />)
-      expect(wrapper.containsMatchingElement(text)).toEqual(true)
+      expect(wrapper.containsMatchingElement(text)).to.be.true
     })
 
     it('Should display failed text', () => {
       const text = <div>En échec</div>
       const wrapper = shallow(<HarvestRow harvest={harvestFailed} previousHarvest={harvestFailed} catalog={catalog} />)
-      expect(wrapper.containsMatchingElement(text)).toEqual(true)
+      expect(wrapper.containsMatchingElement(text)).to.be.true
     })
   })
 
@@ -44,7 +44,7 @@ describe('<HarvestRow />', () => {
     it('Should render a link to harvest details', () => {
       const link = <Link to={`/catalogs/${catalog.id}/harvest/${harvestSuccessed._id}`}>Détails</Link>
       const wrapper = shallow(<HarvestRow harvest={harvestSuccessed} previousHarvest={harvestSuccessed} catalog={catalog} />)
-      expect(wrapper.contains(link)).toEqual(true)
+      expect(wrapper.contains(link)).to.be.true
     })
   })
 })

--- a/src/components/Home/__test__/Home.test.js
+++ b/src/components/Home/__test__/Home.test.js
@@ -15,8 +15,8 @@ describe('<Home />', () => {
       return wrapper
         .instance()
         .componentWillMount()
-        .then(() => expect(wrapper.state('metrics')).toEqual(metrics))
-        .then(() => expect(wrapper.state('errors')).toEqual([]))
+        .then(() => expect(wrapper.state('metrics')).to.deep.equal(metrics))
+        .then(() => expect(wrapper.state('errors')).to.deep.equal([]))
     });
   })
 

--- a/src/components/Loader/__test__/ContentLoader.test.js
+++ b/src/components/Loader/__test__/ContentLoader.test.js
@@ -8,14 +8,14 @@ describe('<ContentLoader />', () => {
     const loader = <CircularProgress size={2} />
     const wrapper = shallow(<ContentLoader />)
 
-    expect(wrapper.containsMatchingElement(loader)).toBe(true)
+    expect(wrapper.containsMatchingElement(loader)).to.be.true
   })
 
   it('should display a CircularProgress with a size of 3', () => {
     const loader = <CircularProgress size={3} />
     const wrapper = shallow(<ContentLoader size={3} />)
 
-    expect(wrapper.containsMatchingElement(loader)).toBe(true)
+    expect(wrapper.containsMatchingElement(loader)).to.be.true
   })
 
   it('should display a CircularProgress with specific style', () => {
@@ -25,6 +25,6 @@ describe('<ContentLoader />', () => {
     const loader = <CircularProgress style={style} size={2} />
     const wrapper = shallow(<ContentLoader style={style} />)
 
-    expect(wrapper.contains(loader)).toBe(true)
+    expect(wrapper.contains(loader)).to.be.true
   })
 })

--- a/src/components/Loader/__test__/Loader.test.js
+++ b/src/components/Loader/__test__/Loader.test.js
@@ -8,12 +8,12 @@ describe('Loader', () => {
     const loader =  <CircularProgress size={1} />
     const wrapper = shallow(<Loader value={undefined} component={<Component />} />)
 
-    expect(wrapper.contains(loader)).toBe(true)
+    expect(wrapper.contains(loader)).to.be.true
   })
 
   it('should display a component when value is defined', () => {
     const component =  <Component />
     const wrapper = shallow(<Loader value={1} component={component} />)
-    expect(wrapper.contains(component)).toBe(true)
+    expect(wrapper.contains(component)).to.be.true
   })
 })

--- a/src/fetch/__test__/fetch.test.js
+++ b/src/fetch/__test__/fetch.test.js
@@ -18,6 +18,6 @@ describe('buildSearchQuery()', () => {
       componentState.filters,
       componentState.page,
     )
-    expect(builQuery).toEqual(expectedUrl)
+    expect(builQuery).to.equal(expectedUrl)
   })
 })

--- a/src/helpers/__test__/components.test.js
+++ b/src/helpers/__test__/components.test.js
@@ -38,7 +38,7 @@ describe('components', () => {
     it('should return when component has no promises', () => {
       const component = shallow(<TestComponent />)
 
-      expect(cancelAllPromises(component)).toNotExist()
+      expect(cancelAllPromises(component)).to.not.exist
     })
 
     it('should return cancelAll function', () => {
@@ -48,8 +48,8 @@ describe('components', () => {
       const canceledPromises = component.cancelablePromises.map(c => reflect(c.promise))
 
       return Promise.all(canceledPromises, canceledPromise => {
-        expect(canceledPromise.isRejected()).toBe(true)
-        expect(canceledPromise.reason.isCanceled).toBe(true)
+        expect(canceledPromise.isRejected()).to.be.true
+        expect(canceledPromise.reason.isCanceled).to.be.true
       })
     })
   })
@@ -58,9 +58,9 @@ describe('components', () => {
     it('should create a cancelablePromises array to component when no exist', () => {
       const component = shallow(<TestComponent />).instance()
 
-      expect(component.cancelablePromises).toNotExist()
+      expect(component.cancelablePromises).to.not.exist
       waitForDataAndSetState(fakePromise(), component, 'stateName')
-      expect(component.cancelablePromises).toExist()
+      expect(component.cancelablePromises).to.exist
     })
 
     it('should add to cancelablePromises component array new cancelablePromise', () => {
@@ -68,7 +68,7 @@ describe('components', () => {
       component.cancelablePromises = []
 
       waitForDataAndSetState(fakePromise(), component, 'stateName')
-      expect(component.cancelablePromises.length).toEqual(1)
+      expect(component.cancelablePromises.length).to.equal(1)
     })
 
     describe('resolve', () => {
@@ -76,7 +76,7 @@ describe('components', () => {
         const component = shallow(<TestComponent />).instance()
 
         return waitForDataAndSetState(Promise.resolve('fakeResolve'), component, 'stateName')
-          .then(() => expect(component.state.stateName).toExist())
+          .then(() => expect(component.state.stateName).to.exist)
       })
     })
 
@@ -85,7 +85,7 @@ describe('components', () => {
         const component = shallow(<TestComponent />).instance()
 
         return waitForDataAndSetState(rejectedPromise(), component, 'stateName')
-          .then(() => expect(component.state.errors.length).toEqual(1))
+          .then(() => expect(component.state.errors.length).to.equal(1))
       })
 
       it('should not assing twice error to state', () => {
@@ -93,9 +93,9 @@ describe('components', () => {
 
         return waitForDataAndSetState(rejectedPromise(), component, 'stateName')
           .then(() => {
-            expect(component.state.errors.length).toEqual(1)
+            expect(component.state.errors.length).to.equal(1)
             return waitForDataAndSetState(rejectedPromise(), component, 'stateName')
-              .then(() => expect(component.state.errors.length).toEqual(1))
+              .then(() => expect(component.state.errors.length).to.equal(1))
         })
       })
     })

--- a/src/helpers/__test__/manageFilters.test.js
+++ b/src/helpers/__test__/manageFilters.test.js
@@ -5,19 +5,19 @@ describe('manageFilters', () => {
   describe('addFilter()', () => {
     it('should add a new filter', () => {
       const filters = addFilter([], {name: 'test', value: 42})
-      expect(filters).toEqual([{name: 'test', value: 42}])
+      expect(filters).to.deep.equal([{name: 'test', value: 42}])
     })
 
     it('should add a new value to an existing filter', () => {
       let filters = addFilter([], {name: 'test', value: 42})
       filters = addFilter(filters, {name: 'test', value: 21})
-      expect(filters).toEqual([{name: 'test', value: 42}, {name: 'test', value:21}])
+      expect(filters).to.deep.equal([{name: 'test', value: 42}, {name: 'test', value:21}])
     })
 
     it('should not add an existing value', () => {
       let filters = addFilter([], {name: 'test', value: 42})
       filters = addFilter(filters, {name: 'test', value: 42})
-      expect(filters).toEqual([{name: 'test', value: 42}])
+      expect(filters).to.deep.equal([{name: 'test', value: 42}])
     })
   })
 
@@ -25,18 +25,18 @@ describe('manageFilters', () => {
     it('should remove a filter', () => {
       let filters = [{name: 'foo', value: 'bar'}, {name: 'test', value: 42}]
       filters = removeFilter(filters, {name: 'test', value: 42})
-      expect(filters).toEqual([{name: 'foo', value: 'bar'}])
+      expect(filters).to.deep.equal([{name: 'foo', value: 'bar'}])
     })
 
     it('should have no effect when filter does not exist', () => {
       const filters = removeFilter([], {name: 'test', value: 21})
-      expect(filters).toEqual([])
+      expect(filters).to.deep.equal([])
     })
 
     it('should have no effect when value does not exist', () => {
       const filter = [{name: 'test', value: 42}]
       const filters = removeFilter(filter, {name: 'test', value: 21})
-      expect(filters).toEqual(filter)
+      expect(filters).to.deep.equal(filter)
     })
   })
 
@@ -45,14 +45,14 @@ describe('manageFilters', () => {
       let filters = [{name: 'foo', value: 'bar'}, {name: 'test', value: 0}]
 
       filters = replaceFilter(filters, {name: 'test', value: 42})
-      expect(filters).toEqual([{name: 'foo', value: 'bar'}, {name: 'test', value: 42}])
+      expect(filters).to.deep.equal([{name: 'foo', value: 'bar'}, {name: 'test', value: 42}])
     })
 
     it('should create when filter do not exist', () => {
       let filters = [{name: 'foo', value: 'bar'}]
 
       filters = replaceFilter(filters, {name: 'test', value: 42})
-      expect(filters).toEqual([{name: 'foo', value: 'bar'}, {name: 'test', value: 42}])
+      expect(filters).to.deep.equal([{name: 'foo', value: 'bar'}, {name: 'test', value: 42}])
     })
   })
 
@@ -69,7 +69,7 @@ describe('manageFilters', () => {
       }
       const result = convertFilters(filters)
 
-      expect(result).toEqual(convertedFilters)
+      expect(result).to.deep.equal(convertedFilters)
     })
   })
 
@@ -79,7 +79,7 @@ describe('manageFilters', () => {
       const filters = [{name: 'keywords', value: 'keyword1'}]
 
       const result = isActive(filters, filter)
-      expect(result).toBe(true)
+      expect(result).to.deep.equal(true)
     })
 
     it('should return false', () => {
@@ -87,7 +87,7 @@ describe('manageFilters', () => {
       const filters = [{name: 'keywords', value: 'keyword1'}]
 
       const result = isActive(filters, filter)
-      expect(result).toBe(false)
+      expect(result).to.deep.equal(false)
     })
   })
 })

--- a/src/helpers/__test__/promises.test.js
+++ b/src/helpers/__test__/promises.test.js
@@ -17,8 +17,8 @@ describe('promises', () => {
       it('should resolve value when hasCanceled_ is false', () => {
         resolveFn('foo')
         return reflect(p.promise).then(inspection => {
-          expect(inspection.isFulfilled()).toBe(true)
-          expect(inspection.value()).toBe('foo')
+          expect(inspection.isFulfilled()).to.be.true
+          expect(inspection.value()).to.equal('foo')
         })
       })
 
@@ -26,8 +26,8 @@ describe('promises', () => {
         p.cancel()
         resolveFn('foo')
         return reflect(p.promise).then(inspection => {
-          expect(inspection.isRejected()).toBe(true)
-          expect(inspection.reason().isCanceled).toBe(true)
+          expect(inspection.isRejected()).to.be.true
+          expect(inspection.reason().isCanceled).to.be.true
         })
       })
     })
@@ -42,9 +42,9 @@ describe('promises', () => {
       it('should reject error when hasCanceled_ is false', () => {
         rejectFn('foo')
         return reflect(p.promise).then(inspection => {
-          expect(inspection.isRejected()).toBe(true)
-          expect(inspection.reason()).toBe('foo')
-          expect(inspection.reason().isCanceled).toNotExist()
+          expect(inspection.isRejected()).to.be.true
+          expect(inspection.reason()).to.equal('foo')
+          expect(inspection.reason().isCanceled).to.not.exist
         })
       })
 
@@ -52,8 +52,8 @@ describe('promises', () => {
         p.cancel()
         rejectFn('foo')
         return reflect(p.promise).then(inspection => {
-          expect(inspection.isRejected()).toBe(true)
-          expect(inspection.reason().isCanceled).toBe(true)
+          expect(inspection.isRejected()).to.be.true
+          expect(inspection.reason().isCanceled).to.be.true
         })
       })
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,7 +1075,7 @@ chart.js@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-1.1.1.tgz#a9b17054220bd45cbdb176fd6bcb8783ef871a7d"
 
-cheerio@^0.22.0:
+cheerio, cheerio@^0.22.0:
   version "0.22.0"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.22.0.tgz#a9baa860a3f9b595a6b81b1a86873121ed3a269e"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -164,6 +164,10 @@ assert@^1.1.1:
   dependencies:
     util "0.10.3"
 
+assertion-error@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
+
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
@@ -1019,6 +1023,21 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
+chai:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"
+  dependencies:
+    assertion-error "^1.0.1"
+    deep-eql "^0.1.3"
+    type-detect "^1.0.0"
+
+chai-enzyme:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/chai-enzyme/-/chai-enzyme-0.6.1.tgz#585c963c6ea1331446efd12ee8391e807d758620"
+  dependencies:
+    html "^1.0.0"
+    react-element-to-jsx-string "^5.0.0"
+
 chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3, chalk@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -1149,6 +1168,10 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+collapse-white-space@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.2.tgz#9c463fb9c6d190d2dcae21a356a01bcae9eeef6d"
+
 color-convert@^1.3.0:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.8.2.tgz#be868184d7c8631766d54e7078e2672d7c7e3339"
@@ -1228,7 +1251,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.6:
+concat-stream@^1.4.6, concat-stream@^1.4.7:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.5.2.tgz#708978624d856af41a5a741defdd261da752c266"
   dependencies:
@@ -1462,6 +1485,12 @@ decamelize@^1.0.0, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+deep-eql@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
+  dependencies:
+    type-detect "0.1.1"
+
 deep-equal@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -1612,6 +1641,10 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+editions@^1.1.1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/editions/-/editions-1.3.3.tgz#0907101bdda20fac3cbe334c27cbd0688dc99a5b"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -2415,6 +2448,12 @@ html-webpack-plugin@2.22.0:
     pretty-error "^2.0.0"
     toposort "^1.0.0"
 
+html@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/html/-/html-1.0.0.tgz#a544fa9ea5492bfb3a2cca8210a10be7b5af1f61"
+  dependencies:
+    concat-stream "^1.4.7"
+
 htmlparser2@^3.9.1:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
@@ -2733,6 +2772,12 @@ is-plain-obj@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
+is-plain-object@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.1.tgz#4d7ca539bc9db9b737b8acb612f2318ef92f294f"
+  dependencies:
+    isobject "^1.0.0"
+
 is-posix-bracket@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
@@ -2748,6 +2793,10 @@ is-property@^1.0.0:
 is-regex@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.3.tgz#0d55182bddf9f2fde278220aec3a75642c908637"
+
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
 
 is-resolvable@^1.0.0:
   version "1.0.0"
@@ -2798,6 +2847,10 @@ isarray@0.0.1:
 isexe@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz#36f3e22e60750920f5e7241a476a8c6a42275ad0"
+
+isobject@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-1.0.2.tgz#f0f9b8ce92dd540fa0740882e3835a2e022ec78a"
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -3128,7 +3181,7 @@ lodash.words@^3.0.0:
   dependencies:
     lodash._root "^3.0.0"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.2, lodash@^4.15.0, lodash@^4.16.2, lodash@^4.16.4, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.2, lodash@^4.15.0, lodash@^4.16.2, lodash@^4.16.4, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
 
@@ -4055,6 +4108,17 @@ react-dom@^15.4:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
 
+react-element-to-jsx-string@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/react-element-to-jsx-string/-/react-element-to-jsx-string-5.0.2.tgz#8d43d815079b44ec5caf87e25f520fe5af853fe4"
+  dependencies:
+    collapse-white-space "^1.0.0"
+    is-plain-object "^2.0.1"
+    lodash "^4.17.2"
+    sortobject "^1.0.0"
+    stringify-object "^2.4.0"
+    traverse "^0.6.6"
+
 react-leaflet:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-leaflet/-/react-leaflet-1.0.1.tgz#aac306d71b8d9aa24b63487801a2c2f8598885dc"
@@ -4467,6 +4531,12 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
+sortobject@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/sortobject/-/sortobject-1.1.1.tgz#4f695d4d44ed0a4c06482c34c2582a2dcdc2ab34"
+  dependencies:
+    editions "^1.1.1"
+
 source-list-map@^0.1.4, source-list-map@~0.1.0:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.6.tgz#e1e6f94f0b40c4d28dcf8f5b8766e0e45636877f"
@@ -4549,6 +4619,13 @@ string-width@^2.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^3.0.0"
+
+stringify-object@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-2.4.0.tgz#c62d11023eb21fe2d9b087be039a26df3b22a09d"
+  dependencies:
+    is-plain-obj "^1.0.0"
+    is-regexp "^1.0.0"
 
 stringstream@~0.0.4:
   version "0.0.5"
@@ -4686,6 +4763,10 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
 
+traverse@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
+
 tryit@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
@@ -4707,6 +4788,14 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
+
+type-detect@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
 
 type-is@~1.6.13:
   version "1.6.14"


### PR DESCRIPTION
Le bouton "Télécharger" est remplacé par un lien sur le nom du `dataset`.
Cela permet de simplifier le code et d'aérer la page. 

Chai-Enzyme
-----------
`except` a été remplacé par `chai` et `chai-enzyme` afin d'avoir des retours d'erreurs un peu plus intéressant que `excepted true to be false`.