### PR TITLE
Gestion des données non vectorielles

### DIFF
--- a/src/components/Checks/CheckDataAvailability.js
+++ b/src/components/Checks/CheckDataAvailability.js
@@ -10,7 +10,10 @@ class DatasetDataAvailability extends Component {
       return {
         valid: true,
         msg: 'Au moins une des distribution est disponible.',
-        content: distributions.map((distribution, idx) => <CheckItem key={idx} name={distribution.typeName || distribution.layer} valid={distribution.available} />),
+        content: distributions.map((distribution, idx) => {
+          const name = distribution.typeName || distribution.layer || distribution.name
+          return <CheckItem key={idx} name={name} valid={distribution.available} />
+        }),
       }
     }
 

--- a/src/components/Downloads/DownloadDatasets.js
+++ b/src/components/Downloads/DownloadDatasets.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import { filter } from 'lodash'
 import PreviewMap from '../Map/PreviewMap'
 import VectorDownload from '../Downloads/VectorDownload'
 import OtherDownload from '../Downloads/OtherDownload'
@@ -39,8 +38,8 @@ class DownloadDatasets extends Component {
   render() {
     const { distributions, style } = this.props
     const { format, preview, geojson, errors } = this.state
-    const vectorDistributions = filter(distributions, (distribution) => !distribution.originalDistribution)
-    const otherDistributions = filter(distributions, (distribution) => distribution.originalDistribution === true)
+    const vectorDistributions = distributions.filter(distribution => !distribution.originalDistribution)
+    const otherDistributions = distributions.filter(distribution => distribution.originalDistribution === true)
 
     let map = <div style={{marginLeft: '40%'}}></div>
     if (preview) {
@@ -50,7 +49,7 @@ class DownloadDatasets extends Component {
         loading={preview && !geojson}
         errors={errors}/>
     }
-    
+
     return (
       <div style={style.section}>
         <h3 style={style.title}>Téléchargements</h3>

--- a/src/components/Downloads/DownloadDatasets.js
+++ b/src/components/Downloads/DownloadDatasets.js
@@ -42,6 +42,15 @@ class DownloadDatasets extends Component {
     const vectorDistributions = filter(distributions, (distribution) => !distribution.originalDistribution)
     const otherDistributions = filter(distributions, (distribution) => distribution.originalDistribution === true)
 
+    let map = <div style={{marginLeft: '40%'}}></div>
+    if (preview) {
+    map = <PreviewMap
+        distribution={preview ? preview.distribution : null}
+        geojson={geojson}
+        loading={preview && !geojson}
+        errors={errors}/>
+    }
+    
     return (
       <div style={style.section}>
         <h3 style={style.title}>Téléchargements</h3>
@@ -55,11 +64,7 @@ class DownloadDatasets extends Component {
               preview={preview} />
             {otherDistributions.length ? <OtherDownload distributions={otherDistributions} /> : null}
           </div>
-          <PreviewMap
-            distribution={preview ? preview.distribution : null}
-            geojson={geojson}
-            loading={preview && !geojson}
-            errors={errors}/>
+          {map}
         </div>
       </div>
     )

--- a/src/components/Downloads/DownloadDatasets.js
+++ b/src/components/Downloads/DownloadDatasets.js
@@ -1,33 +1,20 @@
 import React, { Component } from 'react'
-import Download from './Download'
-import Formats from './Formats'
+import { filter } from 'lodash'
 import PreviewMap from '../Map/PreviewMap'
+import VectorDownload from '../Downloads/VectorDownload'
+import OtherDownload from '../Downloads/OtherDownload'
 import { fetchGeoJSON } from '../../fetch/fetch'
 import { waitForDataAndSetState, cancelAllPromises } from '../../helpers/components'
 
-const FORMATS = [
-  {label: 'GeoJSON', format: 'GeoJSON', projection: 'WGS84'},
-  {label: 'SHP/L93', format: 'SHP', projection: 'Lambert93'},
-  {label: 'SHP/W84', format: 'SHP', projection: 'WGS84'},
-  {label: 'KML', format: 'KML', projection: 'WGS84'},
-  {label: 'CSV', format: 'CSV', projection: 'WGS84'},
-]
-
 const styles = {
-  formats: {
-    margin: '0.5em 0em 1em',
-  },
-  downloads: {
+  content: {
     display: 'flex',
     justifyContent: 'space-between',
   },
-  download: {
-    flexWrap: 'wrap',
-    margin: '5px',
-    paddingLeft: '10px',
+  vector: {
     display: 'flex',
-    alignItems: 'baseline',
     justifyContent: 'space-between',
+    marginBottom: '50px',
   },
 }
 
@@ -35,14 +22,9 @@ class DownloadDatasets extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      format: FORMATS[0], // GeoJSON
       preview: null,
       errors: [],
     }
-  }
-
-  selectFormat(format) {
-    this.setState({format})
   }
 
   selectPreview(preview) {
@@ -57,38 +39,28 @@ class DownloadDatasets extends Component {
   render() {
     const { distributions, style } = this.props
     const { format, preview, geojson, errors } = this.state
-    let downloads
-
-    if (!distributions.length) {
-       downloads = <div>{'Aucune donnée n\'est téléchargeable.'}</div>
-    } else {
-      downloads =
-          <div style={styles.downloads}>
-            <div style={{flexGrow: 1}}>
-              <div>Sélectionner un format de téléchargement :</div>
-                <Formats style={styles.formats} active={format} changeFormat={(format) => this.selectFormat(format)} formats={FORMATS}/>
-                  {this.props.distributions.map((distribution, idx) =>
-                    <Download
-                      style={styles.download}
-                      key={idx}
-                      distribution={distribution}
-                      dlFormat={format}
-                      isPreview={preview && preview.distribution._id === distribution._id}
-                      preview={(preview) => this.selectPreview(preview)} />
-                  )}
-            </div>
-            <PreviewMap
-              distribution={preview ? preview.distribution : null}
-              geojson={geojson}
-              loading={preview && !geojson}
-              errors={errors}/>
-          </div>
-    }
+    const vectorDistributions = filter(distributions, (distribution) => !distribution.originalDistribution)
+    const otherDistributions = filter(distributions, (distribution) => distribution.originalDistribution === true)
 
     return (
       <div style={style.section}>
         <h3 style={style.title}>Téléchargements</h3>
-        {downloads}
+        <div style={styles.content}>
+          <div style={{flexGrow: 1}}>
+            <VectorDownload
+              style={styles.vector}
+              distributions={vectorDistributions}
+              format={format}
+              choosePreview={(format) => this.selectPreview(format)}
+              preview={preview} />
+            {otherDistributions.length ? <OtherDownload distributions={otherDistributions} /> : null}
+          </div>
+          <PreviewMap
+            distribution={preview ? preview.distribution : null}
+            geojson={geojson}
+            loading={preview && !geojson}
+            errors={errors}/>
+        </div>
       </div>
     )
   }

--- a/src/components/Downloads/OtherDownload.js
+++ b/src/components/Downloads/OtherDownload.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+const OtherDownload = ({ distributions, style }) => {
+  return (
+    <div style={style}>
+      <h3>Autres Données</h3>
+      {distributions.map((distribution, idx) => {
+        if (distribution.available) {
+          return <a key={idx} href={distribution.location}>{distribution.name}</a>          
+        }
+        return <div key={idx}>{distribution.name}</div>
+      }
+      )}
+    </div>
+  )
+}
+
+export default OtherDownload

--- a/src/components/Downloads/VectorDownload.js
+++ b/src/components/Downloads/VectorDownload.js
@@ -1,0 +1,75 @@
+import React, { Component } from 'react'
+import Download from './Download'
+import Formats from './Formats'
+
+const FORMATS = [
+  {label: 'GeoJSON', format: 'GeoJSON', projection: 'WGS84'},
+  {label: 'SHP/L93', format: 'SHP', projection: 'Lambert93'},
+  {label: 'SHP/W84', format: 'SHP', projection: 'WGS84'},
+  {label: 'KML', format: 'KML', projection: 'WGS84'},
+  {label: 'CSV', format: 'CSV', projection: 'WGS84'},
+]
+
+const styles = {
+  formats: {
+    margin: '0.5em 0em 1em',
+  },
+  vector: {
+    flexGrow: 1,
+    marginRight: '5%',
+  },
+  download: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    marginBottom: '2px',
+    paddingLeft: '10px',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+  },
+}
+
+class VectorDownload extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { format: FORMATS[0] } // GeoJSON
+  }
+
+  selectFormat(format) {
+    this.setState({format})
+  }
+
+  render() {
+    const { format } = this.state
+    const { distributions, preview, choosePreview, style } = this.props
+
+    let content
+    if (!distributions.length) {
+      content = <div>{'Aucune donnée n\'est téléchargeable.'}</div>
+    } else {
+      content = <div>
+                  <div>Sélectionner un format de téléchargement :</div>
+                  <Formats style={styles.formats} active={format} changeFormat={(format) => this.selectFormat(format)} formats={FORMATS}/>
+                  {distributions.map((distribution, idx) =>
+                    <Download
+                      style={styles.download}
+                      key={idx}
+                      distribution={distribution}
+                      dlFormat={format}
+                      isPreview={preview && preview.distribution._id === distribution._id}
+                      preview={(preview) => choosePreview(preview)} />
+                  )}
+                </div>
+    }
+
+    return (
+      <div style={style}>
+        <div style={styles.vector}>
+          <h3>Données vectorielles</h3>
+          {content}
+        </div>
+      </div>
+    )
+  }
+}
+
+export default VectorDownload


### PR DESCRIPTION
Permet de télécharger les données non vectorielles.

Edit: 
---
La carte ne s'affichera que lorsque qu'une pré-visualisation est sélectionnée.

Fix #138 