### PR TITLE
Tri des catalogues et avertissement pour les vieux catalogues

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "bluebird": "^3.4.6",
     "case-sensitive-paths-webpack-plugin": "1.1.4",
     "chalk": "1.1.3",
+    "chai": "^3.5.0",
+    "chai-enzyme": "^0.6.1",
+    "chart.js": "^1.1.1",
+    "cheerio": "^0.22.0",
     "connect-history-api-fallback": "1.3.0",
     "cross-spawn": "4.0.0",
     "css-loader": "0.24.0",
@@ -54,10 +58,6 @@
     "webpack-dev-server": "1.16.1"
   },
   "dependencies": {
-    "chai": "^3.5.0",
-    "chai-enzyme": "^0.6.1",
-    "chart.js": "^1.1.1",
-    "cheerio": "^0.22.0",
     "json-loader": "^0.5.4",
     "leaflet": "^1.0.2",
     "marked": "^0.3.6",

--- a/src/components/Catalog/CatalogPreview.js
+++ b/src/components/Catalog/CatalogPreview.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router'
 import LastHarvestStatus from '../LastHarvestStatus/LastHarvestStatus'
 import Counter from '../Statistics/Counter/Counter'
 import Percent from '../Statistics/Percent/Percent'
+import ObsoleteWarning from './ObsoleteWarning'
 import { get } from 'lodash'
 import { theme } from '../../tools'
 
@@ -44,7 +45,8 @@ const CatalogPreview = ({ catalog }) => {
     <Link to={`/catalogs/${catalog._id}`} style={styles.link}>
       <div style={styles.paper}>
         <div style={styles.title}>{catalog.name}</div>
-        <LastHarvestStatus harvest={catalog.service.sync}/>
+        <LastHarvestStatus harvest={catalog.service.sync} />
+        <ObsoleteWarning catalog={catalog} />
         <div style={styles.container}>
           <Percent value={openness} total={catalog.metrics.datasets.totalCount} label="Données ouvertes" icon="unlock alternate icon" />
           <Percent value={download} total={catalog.metrics.datasets.totalCount} label="Téléchargeable" icon="download" />

--- a/src/components/Catalog/ObsoleteWarning.js
+++ b/src/components/Catalog/ObsoleteWarning.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { isObsolete } from '../../helpers/catalogs'
+import { theme } from '../../tools'
+
+const style = { color: theme.yellow }
+
+const ObsoleteWarning = ({ catalog, refDate }) => {
+  if (!isObsolete(catalog, refDate)) return <span />
+
+  return (
+    <div style={style}>
+      <i className="icon warning"></i> Ce catalogue n'est plus mis à jour
+    </div>
+  )
+}
+
+export default ObsoleteWarning

--- a/src/components/Catalog/ObsoleteWarning.js
+++ b/src/components/Catalog/ObsoleteWarning.js
@@ -4,8 +4,9 @@ import { theme } from '../../tools'
 
 const style = { color: theme.yellow }
 
-const ObsoleteWarning = ({ catalog, refDate }) => {
-  if (!isObsolete(catalog, refDate)) return <span />
+// When testing you may need to define the current date to avoid test cases obsolescence
+const ObsoleteWarning = ({ catalog, currentDate }) => {
+  if (!isObsolete(catalog, currentDate)) return <span />
 
   return (
     <div style={style}>

--- a/src/components/Catalog/ObsoleteWarning.js
+++ b/src/components/Catalog/ObsoleteWarning.js
@@ -9,7 +9,7 @@ const ObsoleteWarning = ({ catalog, refDate }) => {
 
   return (
     <div style={style}>
-      <i className="icon warning"></i> Ce catalogue n'est plus mis à jour
+      <i className="icon warning"></i> Ce catalogue n'a pas été mis à jour depuis plus de 6 mois
     </div>
   )
 }

--- a/src/components/Catalog/__tests__/ObsoleteWarning.test.js
+++ b/src/components/Catalog/__tests__/ObsoleteWarning.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme'
 import ObsoleteWarning from '../ObsoleteWarning'
 
 function shallowForCatalog(catalog) {
-  return shallow(<ObsoleteWarning catalog={catalog} refDate={new Date('2016-07-15')} />)
+  return shallow(<ObsoleteWarning catalog={catalog} currentDate={new Date('2016-07-15')} />)
 }
 
 describe('<ObsoleteWarning />', () => {

--- a/src/components/Catalog/__tests__/ObsoleteWarning.test.js
+++ b/src/components/Catalog/__tests__/ObsoleteWarning.test.js
@@ -18,7 +18,7 @@ describe('<ObsoleteWarning />', () => {
   describe('mostRecentRevisionDate is older than 6 months', () => {
     it('should display the warning', () => {
       const wrapper = shallowForCatalog({ metrics: { mostRecentRevisionDate: new Date('2011-06-01') } })
-      expect(wrapper.text()).to.contain('plus mis à jour')
+      expect(wrapper.text()).to.contain('pas été mis à jour depuis plus de 6 mois')
     })
   })
 

--- a/src/components/Catalog/__tests__/ObsoleteWarning.test.js
+++ b/src/components/Catalog/__tests__/ObsoleteWarning.test.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import ObsoleteWarning from '../ObsoleteWarning'
+
+function shallowForCatalog(catalog) {
+  return shallow(<ObsoleteWarning catalog={catalog} refDate={new Date('2016-07-15')} />)
+}
+
+describe('<ObsoleteWarning />', () => {
+
+  describe('catalog has no mostRecentRevisionDate metric', () => {
+    it('should display nothing', () => {
+      const wrapper = shallowForCatalog({})
+      expect(wrapper.text()).to.be.empty
+    })
+  })
+
+  describe('mostRecentRevisionDate is older than 6 months', () => {
+    it('should display the warning', () => {
+      const wrapper = shallowForCatalog({ metrics: { mostRecentRevisionDate: new Date('2011-06-01') } })
+      expect(wrapper.text()).to.contain('plus mis à jour')
+    })
+  })
+
+  describe('mostRecentRevisionDate is more recent than 6 months', () => {
+    it('should display nothing', () => {
+      const wrapper = shallowForCatalog({ metrics: { mostRecentRevisionDate: new Date('2016-06-01') } })
+      expect(wrapper.text()).to.be.empty
+    })
+  })
+})

--- a/src/components/Catalogs/Catalogs.js
+++ b/src/components/Catalogs/Catalogs.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react'
+import { sortBy } from 'lodash'
+import { computeCatalogScore } from '../../helpers/catalogs'
 import ContentLoader from '../Loader/ContentLoader'
 import CatalogPreview from '../Catalog/CatalogPreview'
 import { fetchCatalogs } from '../../fetch/fetch'
@@ -14,6 +16,7 @@ const styles = {
     marginTop: '5em',
   },
 }
+
 class Catalogs extends Component {
   constructor(props) {
     super(props)
@@ -31,11 +34,12 @@ class Catalogs extends Component {
   render() {
 
     if (!this.state.catalogs) return <div style={styles.loader}><ContentLoader /></div>
+    const sortedCatalogs = sortBy(this.state.catalogs, catalog => -computeCatalogScore(catalog));
 
     return (
       <div className="catalogs">
         <div style={styles.container}>
-          {this.state.catalogs.map((catalog, idx) => <CatalogPreview key={idx} catalog={catalog} />)}
+          {sortedCatalogs.map((catalog, idx) => <CatalogPreview key={idx} catalog={catalog} />)}
         </div>
       </div>
     )

--- a/src/helpers/__test__/catalogs.test.js
+++ b/src/helpers/__test__/catalogs.test.js
@@ -90,52 +90,57 @@ describe('catalogs', function () {
   })
 
   describe('computeCatalogScore(catalog)', () => {
-    [
-      { catalog: {}, expectedValue: 0 },
+    describe('catalog with no metrics', () => {
+      const catalog = {}
+      it('should return 0', () => {
+        expect(computeCatalogScore(catalog, refDate)).to.equal(0)
+      })
+    })
 
-      {
-        catalog: {
-          metrics: {
-            datasets: { totalCount: 0 }
-          }
-        },
-        expectedValue: 0
-      },
+    describe('catalog with totalCount = 0', () => {
+      const catalog = {
+        metrics: {
+          datasets: { totalCount: 0 }
+        }
+      }
+      it('should return 0', () => {
+        expect(computeCatalogScore(catalog, refDate)).to.equal(0)
+      })
+    })
 
-      {
-        catalog: {
-          metrics: {
-            datasets: {
-              totalCount: 1,
-              partitions: {
-                openness: { yes: 1 },
-                download: { yes: 1 },
-              }
-            },
-            mostRecentRevisionDate: new Date('2000-01-01')
-          }
-        },
-        expectedValue: 100 * (100 * 100) * 1
-      },
+    describe('perfect but old catalog', () => {
+      const catalog = {
+        metrics: {
+          datasets: {
+            totalCount: 1,
+            partitions: {
+              openness: { yes: 1 },
+              download: { yes: 1 },
+            }
+          },
+          mostRecentRevisionDate: new Date('2000-01-01')
+        }
+      }
+      it('should return 0', () => {
+        expect(computeCatalogScore(catalog, refDate)).to.equal(100 * (100 * 100) * 1)
+      })
+    })
 
-      {
-        catalog: {
-          metrics: {
-            datasets: {
-              totalCount: 100,
-              partitions: {
-                openness: { yes: 11 },
-                download: { yes: 12 },
-              }
-            },
-            mostRecentRevisionDate: new Date('2016-05-01')
-          }
-        },
-        expectedValue: 11 * (12 * 12) * 10
-      },
-    ].forEach((testCase, idx) => {
-      it(`test case ${idx} should return the expected value: ${testCase.expectedValue}`, () => {
-        expect(computeCatalogScore(testCase.catalog, refDate)).to.equal(testCase.expectedValue)
+    describe('recent but poor catalog', () => {
+      const catalog = {
+        metrics: {
+          datasets: {
+            totalCount: 100,
+            partitions: {
+              openness: { yes: 11 },
+              download: { yes: 12 },
+            }
+          },
+          mostRecentRevisionDate: new Date('2016-05-01')
+        }
+      }
+      it('should return 0', () => {
+        expect(computeCatalogScore(catalog, refDate)).to.equal(11 * (12 * 12) * 10)
       })
     })
   })

--- a/src/helpers/__test__/catalogs.test.js
+++ b/src/helpers/__test__/catalogs.test.js
@@ -1,27 +1,27 @@
 import { computeFreshnessScore, isObsolete, computeOpenScore, computeDownloadableScore, computeCatalogScore } from '../catalogs'
 
 describe('catalogs', function () {
-  const refDate = new Date('2016-07-15')
+  const currentDate = new Date('2016-07-15')
 
   describe('computeFreshnessScore(moment)', function () {
     describe('moment is not defined', function () {
       it('should return 0', function () {
-        expect(computeFreshnessScore(null, refDate)).to.equal(1)
+        expect(computeFreshnessScore(null, currentDate)).to.equal(1)
       })
     })
     describe('moment is more recent than 1 month', function () {
       it('should return 100', function () {
-        expect(computeFreshnessScore(new Date('2016-07-01'), refDate)).to.equal(100)
+        expect(computeFreshnessScore(new Date('2016-07-01'), currentDate)).to.equal(100)
       })
     })
     describe('moment is more recent than 6 months', function () {
       it('should return 10', function () {
-        expect(computeFreshnessScore(new Date('2016-05-01'), refDate)).to.equal(10)
+        expect(computeFreshnessScore(new Date('2016-05-01'), currentDate)).to.equal(10)
       })
     })
     describe('moment is older than 6 months', function () {
       it('should return 0', function () {
-        expect(computeFreshnessScore(new Date('2011-07-01'), refDate)).to.equal(1)
+        expect(computeFreshnessScore(new Date('2011-07-01'), currentDate)).to.equal(1)
       })
     })
   })
@@ -30,19 +30,19 @@ describe('catalogs', function () {
     describe('catalog has no mostRecentRevisionDate metric', () => {
       const catalog = {}
       it('should return undefined', function () {
-        return expect(isObsolete(catalog, refDate)).to.be.undefined
+        return expect(isObsolete(catalog, currentDate)).to.be.undefined
       })
     })
     describe('mostRecentRevisionDate is more recent than 6 months', () => {
       const catalog = { metrics: { mostRecentRevisionDate: new Date('2016-06-01') } }
       it('should return false', function () {
-        return expect(isObsolete(catalog, refDate)).to.be.false
+        return expect(isObsolete(catalog, currentDate)).to.be.false
       })
     })
     describe('mostRecentRevisionDate is older than 6 months', () => {
       const catalog = { metrics: { mostRecentRevisionDate: new Date('2011-06-01') } }
       it('should return true', function () {
-        return expect(isObsolete(catalog, refDate)).to.be.true
+        return expect(isObsolete(catalog, currentDate)).to.be.true
       })
     })
   })
@@ -93,7 +93,7 @@ describe('catalogs', function () {
     describe('catalog with no metrics', () => {
       const catalog = {}
       it('should return 0', () => {
-        expect(computeCatalogScore(catalog, refDate)).to.equal(0)
+        expect(computeCatalogScore(catalog, currentDate)).to.equal(0)
       })
     })
 
@@ -104,7 +104,7 @@ describe('catalogs', function () {
         }
       }
       it('should return 0', () => {
-        expect(computeCatalogScore(catalog, refDate)).to.equal(0)
+        expect(computeCatalogScore(catalog, currentDate)).to.equal(0)
       })
     })
 
@@ -122,7 +122,7 @@ describe('catalogs', function () {
         }
       }
       it('should return 0', () => {
-        expect(computeCatalogScore(catalog, refDate)).to.equal(100 * (100 * 100) * 1)
+        expect(computeCatalogScore(catalog, currentDate)).to.equal(100 * (100 * 100) * 1)
       })
     })
 
@@ -140,7 +140,7 @@ describe('catalogs', function () {
         }
       }
       it('should return 0', () => {
-        expect(computeCatalogScore(catalog, refDate)).to.equal(11 * (12 * 12) * 10)
+        expect(computeCatalogScore(catalog, currentDate)).to.equal(11 * (12 * 12) * 10)
       })
     })
   })

--- a/src/helpers/__test__/catalogs.test.js
+++ b/src/helpers/__test__/catalogs.test.js
@@ -1,0 +1,143 @@
+import { computeFreshnessScore, isObsolete, computeOpenScore, computeDownloadableScore, computeCatalogScore } from '../catalogs'
+
+describe('catalogs', function () {
+  const refDate = new Date('2016-07-15')
+
+  describe('computeFreshnessScore(moment)', function () {
+    describe('moment is not defined', function () {
+      it('should return 0', function () {
+        expect(computeFreshnessScore(null, refDate)).to.equal(1)
+      })
+    })
+    describe('moment is more recent than 1 month', function () {
+      it('should return 100', function () {
+        expect(computeFreshnessScore(new Date('2016-07-01'), refDate)).to.equal(100)
+      })
+    })
+    describe('moment is more recent than 6 months', function () {
+      it('should return 10', function () {
+        expect(computeFreshnessScore(new Date('2016-05-01'), refDate)).to.equal(10)
+      })
+    })
+    describe('moment is older than 6 months', function () {
+      it('should return 0', function () {
+        expect(computeFreshnessScore(new Date('2011-07-01'), refDate)).to.equal(1)
+      })
+    })
+  })
+
+  describe('isObsolete(catalog)', () => {
+    describe('catalog has no mostRecentRevisionDate metric', () => {
+      const catalog = {}
+      it('should return undefined', function () {
+        return expect(isObsolete(catalog, refDate)).to.be.undefined
+      })
+    })
+    describe('mostRecentRevisionDate is more recent than 6 months', () => {
+      const catalog = { metrics: { mostRecentRevisionDate: new Date('2016-06-01') } }
+      it('should return false', function () {
+        return expect(isObsolete(catalog, refDate)).to.be.false
+      })
+    })
+    describe('mostRecentRevisionDate is older than 6 months', () => {
+      const catalog = { metrics: { mostRecentRevisionDate: new Date('2011-06-01') } }
+      it('should return true', function () {
+        return expect(isObsolete(catalog, refDate)).to.be.true
+      })
+    })
+  })
+
+  describe('computeOpenScore(percentOpen)', () => {
+    describe('percentOpen >= 100', () => {
+      it('should return 100', () => {
+        expect(computeOpenScore(500)).to.equal(100)
+        expect(computeOpenScore(100)).to.equal(100)
+      })
+    })
+    describe('percentOpen <= 1', () => {
+      it('should return 1', () => {
+        expect(computeOpenScore(-10)).to.equal(1)
+        expect(computeOpenScore(0)).to.equal(1)
+        expect(computeOpenScore(1)).to.equal(1)
+      })
+    })
+    describe('1 < percentOpen < 100', () => {
+      it('should return the same value', () => {
+        expect(computeOpenScore(47)).to.equal(47)
+      })
+    })
+  })
+
+  describe('computeDownloadableScore(percentDownloadable)', () => {
+    describe('percentDownloadable >= 100', () => {
+      it('should return 100 * 100', () => {
+        expect(computeDownloadableScore(500)).to.equal(100 * 100)
+        expect(computeDownloadableScore(100)).to.equal(100 * 100)
+      })
+    })
+    describe('percentDownloadable <= 1', () => {
+      it('should return 1', () => {
+        expect(computeDownloadableScore(-10)).to.equal(1)
+        expect(computeDownloadableScore(0)).to.equal(1)
+        expect(computeDownloadableScore(1)).to.equal(1)
+      })
+    })
+    describe('1 < percentDownloadable < 100', () => {
+      it('should return squared value', () => {
+        expect(computeDownloadableScore(47)).to.equal(47 * 47)
+      })
+    })
+  })
+
+  describe('computeCatalogScore(catalog)', () => {
+    [
+      { catalog: {}, expectedValue: 0 },
+
+      {
+        catalog: {
+          metrics: {
+            datasets: { totalCount: 0 }
+          }
+        },
+        expectedValue: 0
+      },
+
+      {
+        catalog: {
+          metrics: {
+            datasets: {
+              totalCount: 1,
+              partitions: {
+                openness: { yes: 1 },
+                download: { yes: 1 },
+              }
+            },
+            mostRecentRevisionDate: new Date('2000-01-01')
+          }
+        },
+        expectedValue: 100 * (100 * 100) * 1
+      },
+
+      {
+        catalog: {
+          metrics: {
+            datasets: {
+              totalCount: 100,
+              partitions: {
+                openness: { yes: 11 },
+                download: { yes: 12 },
+              }
+            },
+            mostRecentRevisionDate: new Date('2016-05-01')
+          }
+        },
+        expectedValue: 11 * (12 * 12) * 10
+      },
+    ].forEach((testCase, idx) => {
+      it(`test case ${idx} should return the expected value: ${testCase.expectedValue}`, () => {
+        expect(computeCatalogScore(testCase.catalog, refDate)).to.equal(testCase.expectedValue)
+      })
+    })
+  })
+
+})

--- a/src/helpers/catalogs.js
+++ b/src/helpers/catalogs.js
@@ -1,16 +1,16 @@
 import moment from 'moment'
 import { get } from 'lodash'
 
-export function isObsolete(catalog, refDate = new Date()) {
+export function isObsolete(catalog, currentDate = new Date()) {
   const mostRecentRevisionDate = get(catalog, 'metrics.mostRecentRevisionDate')
   if (!mostRecentRevisionDate) return
-  return (moment(refDate).subtract(6, 'months').isAfter(mostRecentRevisionDate))
+  return (moment(currentDate).subtract(6, 'months').isAfter(mostRecentRevisionDate))
 }
 
-export function computeFreshnessScore(mostRecentRevisionDate, refDate = new Date()) {
+export function computeFreshnessScore(mostRecentRevisionDate, currentDate = new Date()) {
   if (!mostRecentRevisionDate) return 1
-  if (moment(refDate).subtract(1, 'months').isBefore(mostRecentRevisionDate)) return 100
-  if (moment(refDate).subtract(6, 'months').isBefore(mostRecentRevisionDate)) return 10
+  if (moment(currentDate).subtract(1, 'months').isBefore(mostRecentRevisionDate)) return 100
+  if (moment(currentDate).subtract(6, 'months').isBefore(mostRecentRevisionDate)) return 10
   return 1
 }
 
@@ -23,14 +23,14 @@ export function computeOpenScore(percentOpen) {
   return Math.max(Math.min(percentOpen, 100), 1)
 }
 
-export function computeCatalogScore(catalog, refDate) {
+export function computeCatalogScore(catalog, currentDate) {
   const total = get(catalog.metrics, 'datasets.totalCount', 0)
   if (total === 0) return 0
 
   const percentOpen = get(catalog.metrics, 'datasets.partitions.openness.yes', 0) / total * 100
   const percentDownloadable = get(catalog.metrics, 'datasets.partitions.download.yes', 0) / total * 100
 
-  return computeFreshnessScore(catalog.metrics.mostRecentRevisionDate, refDate) *
+  return computeFreshnessScore(catalog.metrics.mostRecentRevisionDate, currentDate) *
     computeDownloadableScore(percentDownloadable) *
     computeOpenScore(percentOpen)
 }

--- a/src/helpers/catalogs.js
+++ b/src/helpers/catalogs.js
@@ -1,0 +1,36 @@
+import moment from 'moment'
+import { get } from 'lodash'
+
+export function isObsolete(catalog, refDate = new Date()) {
+  const mostRecentRevisionDate = get(catalog, 'metrics.mostRecentRevisionDate')
+  if (!mostRecentRevisionDate) return
+  return (moment(refDate).subtract(6, 'months').isAfter(mostRecentRevisionDate))
+}
+
+export function computeFreshnessScore(mostRecentRevisionDate, refDate = new Date()) {
+  if (!mostRecentRevisionDate) return 1
+  if (moment(refDate).subtract(1, 'months').isBefore(mostRecentRevisionDate)) return 100
+  if (moment(refDate).subtract(6, 'months').isBefore(mostRecentRevisionDate)) return 10
+  return 1
+}
+
+export function computeDownloadableScore(percentDownloadable) {
+  const v = Math.max(Math.min(percentDownloadable, 100), 1)
+  return v * v
+}
+
+export function computeOpenScore(percentOpen) {
+  return Math.max(Math.min(percentOpen, 100), 1)
+}
+
+export function computeCatalogScore(catalog, refDate) {
+  const total = get(catalog.metrics, 'datasets.totalCount', 0)
+  if (total === 0) return 0
+
+  const percentOpen = get(catalog.metrics, 'datasets.partitions.openness.yes', 0) / total * 100
+  const percentDownloadable = get(catalog.metrics, 'datasets.partitions.download.yes', 0) / total * 100
+
+  return computeFreshnessScore(catalog.metrics.mostRecentRevisionDate, refDate) *
+    computeDownloadableScore(percentDownloadable) *
+    computeOpenScore(percentOpen)
+}


### PR DESCRIPTION
Cette PR met en place un tri non-empirique des catalogues.

L'algorithme de scoring initial est :

`indicateur d'obsolescence` x `pourcentage de données téléchargeables` ^ 2 x `pourcentage de données ouvertes`

L'indicateur d'obsolescence vaut :

* 100 si le catalogue a été mis à jour il y a moins de 1 mois
* 10 si le catalogue a été mis à jour il y a moins de 6 mois
* 1 sinon

Résultat :

<img width="1149" alt="capture d ecran 2016-12-16 a 16 14 48" src="https://cloud.githubusercontent.com/assets/1231232/21267496/e5633152-c3aa-11e6-9008-e826df6b550a.png">

On affiche aussi un avertissement lorsqu'un catalogue n'a pas été mis à jour depuis plus de 6 mois.

<img width="328" alt="capture d ecran 2016-12-16 a 16 15 03" src="https://cloud.githubusercontent.com/assets/1231232/21267506/ede33520-c3aa-11e6-981f-6f4825f83489.png">
