### PR TITLE
Nouveau composant permettant d'unifier tous les `fetch`

### DIFF
--- a/src/components/Fetch/FetchUp.js
+++ b/src/components/Fetch/FetchUp.js
@@ -1,0 +1,42 @@
+import React, { Component } from 'react'
+import { find } from 'lodash'
+import Errors from '../Errors/Errors'
+import { waitForDataAndSetState, cancelAllPromises } from '../../helpers/components'
+
+class FetchUp extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {errors: []}
+  }
+
+  componentWillMount() {
+    if (!this.props.promises) return
+    const promises = this.props.promises.map(promise =>
+      waitForDataAndSetState(promise.fetch(promise.value), this, promise.name)
+    )
+
+    return Promise.all(promises)
+  }
+
+  componentWillUnmount() {
+    return cancelAllPromises(this)
+  }
+
+  allStateReady() {
+    return !find(this.props.promises, prop => !this.state[prop.name])
+  }
+
+  render() {
+    const { errors } = this.state
+    const { component } = this.props
+
+    if (errors.length) return <Errors errors={errors}/>
+    if (!this.allStateReady() || !component) return null
+
+    const props = {...this.state}
+    delete props.errors
+    return <component.type {...props} />
+  }
+}
+
+export default FetchUp

--- a/src/components/Fetch/__test__/FetchUp.test.js
+++ b/src/components/Fetch/__test__/FetchUp.test.js
@@ -1,0 +1,62 @@
+import React from 'react'
+import { shallow, mount } from 'enzyme'
+import FetchUp from '../FetchUp'
+import Errors from '../../Errors/Errors'
+import CatalogPreview from '../../Catalog/CatalogPreview'
+import { fetchCatalog, fetchMetrics } from '../../../fetch/__mocks__/fetch'
+
+import catalog from '../../../fetch/__test__/catalog.json'
+
+describe('<FetchUp />', () => {
+  const catalogPromise = {fetch: fetchCatalog, name: 'catalog', value: '1'}
+  const metricsPromise = {fetch: fetchMetrics, name: 'metrics', value: '1'}
+
+  describe('allStateReady()', () => {
+    it('should return true when all states are define', () => {
+      const wrapper = shallow(<FetchUp promises={[catalogPromise, metricsPromise]} />)
+
+      wrapper.setState({catalog: 'catalog', metrics: 'metrics'})
+      expect(wrapper.instance().allStateReady()).to.be.true
+    })
+
+    it('should return false when all states aren\'t define', () => {
+      const wrapper = shallow(<FetchUp promises={[catalogPromise, metricsPromise]} />)
+
+      wrapper.setState({catalog: 'catalog', metrics: undefined})
+      expect(wrapper.instance().allStateReady()).to.be.false
+    })
+  })
+
+  describe('render()', () => {
+    describe('When a component is set in props', () => {
+      it('should render component with state', () => {
+        const catalogPreview = <CatalogPreview catalog={catalog} />
+        const wrapper = mount(<FetchUp component={<CatalogPreview />} promises={[catalogPromise]} />)
+
+        return wrapper
+          .instance()
+          .componentWillMount()
+          .then(() => expect(wrapper).to.contain(catalogPreview))
+      })
+    })
+
+    describe('When no component is set in props', () => {
+      it('should render null', () => {
+        const wrapper = shallow(<FetchUp />)
+        expect(wrapper.html()).to.be.null
+      })
+    })
+
+    describe('When an error is saved in errors state', () => {
+      it('should render an Errors component', () => {
+        const errors = [1, 2]
+        const error = <Errors errors={errors} />
+        const wrapper = shallow(<FetchUp />)
+
+        wrapper.setState({errors})
+
+        expect(wrapper).to.contain(error)
+      })
+    })
+  })
+})


### PR DESCRIPTION
FetchUp
=======
Ce nouveau composant permet de d'homogénéiser les requêtes `fetch` en faisant lui-même les requêtes et en créant un nouveau composant choisi auquel il délivrera les données récupéré.

Props
------
`<FetchUp />` attend deux `props`:
- component: Composant retourné par `<FetchUp />`
- promises: Liste d'object sous la forme =>`{fetch: fetchCatalog, name: "catalog", value: ${catalogId}'}`
 

