### PR TITLE
Utilisation de yarn dans CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,9 +2,33 @@ general:
   branches:
     ignore:
       - gh-pages
+
 machine:
+  environment:
+    YARN_VERSION: 0.18.1
+    PATH: "${PATH}:${HOME}/.yarn/bin:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
   node:
     version: 6
+
+dependencies:
+  pre:
+    - |
+      if [[ ! -e ~/.yarn/bin/yarn || $(yarn --version) != "${YARN_VERSION}" ]]; then
+        echo "Download and install Yarn."
+        curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION
+      else
+        echo "The correct version of Yarn is already installed."
+      fi
+  override:
+    - yarn install
+  cache_directories:
+    - ~/.yarn
+    - ~/.cache/yarn
+
+test:
+  override:
+    - yarn test
+
 deployment:
   production:
     branch: master


### PR DESCRIPTION
J'ai simplement suivi ce guide : https://circleci.com/docs/install-and-use-yarn/

Maintenant notre CI s'appuie sur notre fichier `yarn.lock`, on devrait avoir moins de bugs liés au cache npm.