### PR TITLE
Afficher la liste des producteurs

### DIFF
--- a/src/modules/Publication/components/OrganizationProducersPreview/OrganizationProducersPreview.js
+++ b/src/modules/Publication/components/OrganizationProducersPreview/OrganizationProducersPreview.js
@@ -6,6 +6,9 @@ const OrganizationProducersPreview = ({ organizationId, producers }) => {
   return (
     <div>
       <div><strong>{producers.length}</strong> producteurs sont associés à votre organisation</div>
+      <ul>
+        {producers.map((producer, idx) => <li key={idx}>{producer._id}</li>)}
+      </ul>
       <Link className={link} to={`/publication/${organizationId}/producers`}>Associer des producteurs</Link>
     </div>
   )


### PR DESCRIPTION
La liste des producteurs associés est affiché dans `<OrganizationProducersPreview />`
<img width="1175" alt="capture d ecran 2017-01-11 a 21 50 25" src="https://cloud.githubusercontent.com/assets/7040549/21865837/059300cc-d848-11e6-8475-905cbf409ec8.png">
