### PR TITLE
Actualisation des jeux de données lors d'une publication

### DIFF
--- a/src/modules/Publication/components/DatasetToSelect/DatasetToSelect.css
+++ b/src/modules/Publication/components/DatasetToSelect/DatasetToSelect.css
@@ -3,3 +3,7 @@
   justify-content: space-between;
   margin: 1em;
 }
+
+.progress {
+  color: grey;
+}

--- a/src/modules/Publication/components/DatasetToSelect/DatasetToSelect.js
+++ b/src/modules/Publication/components/DatasetToSelect/DatasetToSelect.js
@@ -1,14 +1,16 @@
 import React from 'react'
 import { Link } from 'react-router'
 
-import { data } from './DatasetToSelect.css'
+import { data, progress } from './DatasetToSelect.css'
 
-const DatasetToSelect = ({ dataset, isSelected, change }) => {
+const DatasetToSelect = ({ dataset, isSelected, inProgress, change }) => {
 
   return (
     <div className={data}>
       <Link to={`/datasets/${dataset._id}`}>{dataset.title}</Link>
-      <input type="checkbox" checked={isSelected} onChange={() => change(dataset)} />
+      { isSelected && inProgress ?
+        <div className={progress}>Publication en cours...</div> :
+        <input type="checkbox" checked={isSelected} onChange={() => change(dataset)} />}
     </div>
   )
 }

--- a/src/modules/Publication/components/DatasetsPublication/DatasetsPublication.js
+++ b/src/modules/Publication/components/DatasetsPublication/DatasetsPublication.js
@@ -9,7 +9,7 @@ import { container, header, success, warning, error } from './DatasetsPublicatio
 class DatasetsPublication extends Component {
 
   render() {
-    const { datasets, title, organizationId, status } = this.props
+    const { datasets, title, update, organizationId, status } = this.props
 
     const headerStyle = cx(header, {
       [success]: status === 'success',
@@ -23,7 +23,7 @@ class DatasetsPublication extends Component {
             <div>{title}</div>
             <div>{datasets.length}</div>
           </div>
-          {status === 'error' ? <DatasetsToBePublished datasets={datasets} organizationId={organizationId} /> : <PublishedDatasets datasets={datasets} />}
+          {status === 'error' ? <DatasetsToBePublished datasets={datasets} update={() => update()} organizationId={organizationId} /> : <PublishedDatasets datasets={datasets} />}
         </div>
     )
   }

--- a/src/modules/Publication/components/DatasetsToBePublished/DatasetsToBePublished.css
+++ b/src/modules/Publication/components/DatasetsToBePublished/DatasetsToBePublished.css
@@ -17,6 +17,21 @@
   text-align: center;
 }
 
+button.refresh  {
+  display: flex;
+  align-items: baseline;
+  margin: 0.5em 1em;
+  padding: 10px;
+  color: #fff;
+  border: none;
+  background-color: var(--blue);
+  display: inline-block;
+}
+
+button.refresh i  {
+  margin-left: 10px;
+}
+
 .disable,
 .disable:hover {
   background-color: whitesmoke;

--- a/src/modules/Publication/components/DatasetsToBePublished/DatasetsToBePublished.js
+++ b/src/modules/Publication/components/DatasetsToBePublished/DatasetsToBePublished.js
@@ -4,21 +4,24 @@ import { publishDataset } from '../../../../fetch/fetch'
 
 import DatasetToSelect from '../DatasetToSelect/DatasetToSelect'
 
-import { buttons, noData, publishButton, button, disable, selection } from './DatasetsToBePublished.css'
+import { buttons, noData, publishButton, button, refresh, disable, selection } from './DatasetsToBePublished.css'
 
 class DatasetsToBePublished extends Component {
   constructor(props) {
     super(props)
-    this.state = {toPublish: []}
+    this.state = {
+      toPublish: [],
+      publicationInProgress: false,
+    }
   }
 
   publishDatasets() {
     const { toPublish } = this.state
-    const { organizationId, update } = this.props
+    const { organizationId } = this.props
 
     if (toPublish.length) {
+      this.setState({ publicationInProgress: true })
       toPublish.map( dataset => publishDataset(dataset._id, organizationId))
-      update()
     }
   }
 
@@ -45,8 +48,8 @@ class DatasetsToBePublished extends Component {
   }
 
   render() {
-    const { datasets } = this.props
-    const { toPublish } = this.state
+    const { datasets, update } = this.props
+    const { toPublish, publicationInProgress } = this.state
     const label = toPublish.length === datasets.length ? 'Tout désélectionner' : 'Tout sélectionner'
     const textButton = toPublish.length === datasets.length ? 'Publier toutes les données' : 'Publier les données sélectionnées'
     const publishButtonStyle = toPublish.length ? publishButton : disable
@@ -60,8 +63,10 @@ class DatasetsToBePublished extends Component {
             key={idx}
             dataset={dataset}
             isSelected={isSelected}
+            inProgress={publicationInProgress}
             change={isSelected ? (dataset) => this.removeDatasetToPublish(dataset) : (dataset) => this.addDatasetToPublish(dataset)} />}
         )}
+        { publicationInProgress ? <button className={refresh} onClick={() => update()}>Actualiser les données <i className="refresh icon"></i></button> : null}
         <div className={buttons}>
           <div className={`${button} ${selection}`} onClick={() => this.selection()}>{label}</div>
           <div className={`${button} ${publishButtonStyle}`} onClick={() => this.publishDatasets()}>{textButton}</div>

--- a/src/modules/Publication/components/DatasetsToBePublished/DatasetsToBePublished.js
+++ b/src/modules/Publication/components/DatasetsToBePublished/DatasetsToBePublished.js
@@ -14,10 +14,11 @@ class DatasetsToBePublished extends Component {
 
   publishDatasets() {
     const { toPublish } = this.state
-    const { organizationId } = this.props
+    const { organizationId, update } = this.props
 
     if (toPublish.length) {
-      toPublish.map( dataset => publishDataset(dataset._id, organizationId) )
+      toPublish.map( dataset => publishDataset(dataset._id, organizationId))
+      update()
     }
   }
 

--- a/src/modules/Publication/components/OrganizationDatasets/OrganizationDatasets.js
+++ b/src/modules/Publication/components/OrganizationDatasets/OrganizationDatasets.js
@@ -5,10 +5,10 @@ import DatasetsPublication from '../DatasetsPublication/DatasetsPublication'
 
 import { previousPage } from './OrganizationDatasets.css'
 
-const OrganizationDatasets = ({ published, notPublishedYet, publishedByOthers, organizationId }) => {
+const OrganizationDatasets = ({ published, notPublishedYet, publishedByOthers, update, organizationId }) => {
   return (
     <div>
-      <DatasetsPublication datasets={notPublishedYet} organizationId={organizationId} title={'Données en attente de publication'} status={'error'} />
+      <DatasetsPublication datasets={notPublishedYet} organizationId={organizationId} title={'Données en attente de publication'} status={'error'} update={() => update()} />
       <DatasetsPublication datasets={published} organizationId={organizationId} title={'Données publiées'} status={'success'} />
       <DatasetsPublication datasets={publishedByOthers} organizationId={organizationId} title={'Données publiées par une autre organisation'} status={'warning'} />
       <div className={previousPage}>

--- a/src/modules/Publication/pages/PublishingDatasets/PublishingDatasets.js
+++ b/src/modules/Publication/pages/PublishingDatasets/PublishingDatasets.js
@@ -44,6 +44,13 @@ class PublishingDatasets extends Component {
     return waitForDataAndSetState(fetchOrganizationPublishedByOthers(this.state.organizationId), this, 'publishedByOthers')
   }
 
+  updateDatasets() {
+    return Promise.all([
+      this.updatePublished(),
+      this.updateNotPublishedYet(),
+    ])
+  }
+
   render() {
 
     const { organizationId, user, published, notPublishedYet, publishedByOthers, errors } = this.state
@@ -64,7 +71,7 @@ class PublishingDatasets extends Component {
 
     return (
       <Layout user={user} pageTitle={organization.name} title={'Jeux de données'}>
-        <OrganizationDatasets {...datasets} organizationId={organizationId} />
+        <OrganizationDatasets {...datasets} update={() => this.updateDatasets()} organizationId={organizationId} />
       </Layout>
     )
   }

--- a/src/modules/Publication/pages/PublishingDatasets/__test__/PublishingDatasets.test.js
+++ b/src/modules/Publication/pages/PublishingDatasets/__test__/PublishingDatasets.test.js
@@ -1,8 +1,6 @@
 import React from 'react'
 import { mount } from 'enzyme'
 
-import OrganizationDatasets from '../../../components/OrganizationDatasets/OrganizationDatasets'
-
 import Errors from '../../../../../components/Errors/Errors'
 
 import datasets from '../../../../../fetch/__test__/organizationDatasets.json'
@@ -30,13 +28,14 @@ describe('<PublishingDatasets />', () => {
     })
 
     it('should render a OrganizationDatasets component', () => {
-      const component = <OrganizationDatasets organizationId={'1'} published={datasets} notPublishedYet={notPublishedYet} publishedByOthers={datasets} />
       const wrapper = mount(<PublishingDatasets params={{organizationId: '1'}} />)
 
       return wrapper.instance()
         .componentWillMount()
         .then(() => {
-          expect(wrapper).to.contain(component)
+          expect(wrapper).to.contains.html('<div>Données en attente de publication</div>')
+          expect(wrapper).to.contains.html('<div>Données publiées</div>')
+          expect(wrapper).to.contains.html('<div>Données publiées par une autre organisation</div>')
         })
     })
   })


### PR DESCRIPTION
Quand l'utilisateur publie des données, celles-ci disparaissent des `Données en attente de publication ` pour arriver dans `Données publiées`


<img width="1197" alt="capture d ecran 2017-01-20 a 16 06 17" src="https://cloud.githubusercontent.com/assets/7040549/22154086/693bde44-df2a-11e6-9001-b2caae345871.png">