### PR TITLE
Console log warn

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ general:
 
 machine:
   environment:
-    YARN_VERSION: 0.18.1
+    YARN_VERSION: 0.19.1
     PATH: "${PATH}:${HOME}/.yarn/bin:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
   node:
     version: 6

--- a/circle.yml
+++ b/circle.yml
@@ -27,6 +27,7 @@ dependencies:
 
 test:
   override:
+    - yarn lint
     - yarn test
 
 deployment:

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
         "error",
         "single"
       ],
-      "no-console": "error",
+      "no-console": "warn",
       "no-debugger": "error",
       "mocha/no-exclusive-tests": "error"
     }


### PR DESCRIPTION
- Les `console.log()` provoque un `warning` et plus une `error`
- CircleCI lance le `linter`
- Mise à jour de yarn en `v0.19.1` sur CircleCI