### PR TITLE
Corrige le chargement infini lorsqu'une erreur survient

### DIFF
--- a/src/components/Errors/Errors.css
+++ b/src/components/Errors/Errors.css
@@ -1,0 +1,15 @@
+@import "../../theme/colors";
+
+.container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  text-align: center;
+  color: var(--blue);
+  margin-top: 2em;
+}
+
+.container h3 {
+  font-size: 4em;
+}

--- a/src/components/Errors/Errors.js
+++ b/src/components/Errors/Errors.js
@@ -1,20 +1,17 @@
 import React from 'react'
 import DocumentTitle from 'react-document-title'
 
-const styles = {
-    errors: {
-      width: '90%',
-      textAlign: 'center',
-    }
-}
+import { container } from './Errors.css'
 
 const Errors = ({ errors }) => {
-  const title = errors.length > 1 ? <h3>Des erreurs sont survenues :</h3> : <h3>Une erreur est survenue :</h3>
+  const title = errors.length > 1 ? <h3>Des erreurs sont survenues</h3> : <h3>Une erreur est survenue</h3>
   return (
     <DocumentTitle title={'Erreur'}>
-      <div style={styles.errors}>
+      <div className={container}>
         {title}
-        {errors.map((error, idx) => <div key={idx}>{error}</div>)}
+        <ul>
+          {errors.map((error, idx) => <li key={idx}>{error}</li>)}
+        </ul>
       </div>
     </DocumentTitle>
   )

--- a/src/components/Errors/__test__/Errors.test.js
+++ b/src/components/Errors/__test__/Errors.test.js
@@ -8,7 +8,7 @@ describe('<Errors />', () => {
 
     it('should display a sentence in the singular', () => {
       const error = ['une erreur']
-      const title = <h3>Une erreur est survenue :</h3>
+      const title = <h3>Une erreur est survenue</h3>
       const wrapper = shallow(<Errors errors={error} />)
 
       expect(wrapper).to.contain(title)
@@ -16,10 +16,9 @@ describe('<Errors />', () => {
   })
 
   describe('Several errors', () => {
-
-    it('Should display a sentence in the plural', () => {
+    it('should display a sentence in the plural', () => {
       const errors = ['une erreur', 'une deuxième erreur']
-      const title = <h3>Des erreurs sont survenues :</h3>
+      const title = <h3>Des erreurs sont survenues</h3>
       const wrapper = shallow(<Errors errors={errors} />)
 
       expect(wrapper).to.contain(title)
@@ -29,8 +28,8 @@ describe('<Errors />', () => {
   describe('When at least one error exists', () => {
     it('Should display all errors', () => {
       const errors = ['une erreur', 'une deuxième erreur']
-      const error1 = <div>une erreur</div>
-      const error2 = <div>une deuxième erreur</div>
+      const error1 = <li>une erreur</li>
+      const error2 = <li>une deuxième erreur</li>
       const wrapper = shallow(<Errors errors={errors} />)
 
       expect(wrapper).to.contain(error1)

--- a/src/components/NotFound/NotFound.css
+++ b/src/components/NotFound/NotFound.css
@@ -6,7 +6,7 @@
   align-items: center;
   color: var(--blue);
   font-size: 2em;
-  margin-top: 2em;
+  margin: 2em;
 }
 
 .notFound h1 {

--- a/src/modules/Catalogs/pages/CatalogDetail/CatalogDetail.js
+++ b/src/modules/Catalogs/pages/CatalogDetail/CatalogDetail.js
@@ -50,7 +50,9 @@ class CatalogDetail extends Component {
   }
 
   render() {
-    const { catalog, metrics } = this.state
+    const { catalog, metrics, errors } = this.state
+
+    if (errors.length) return <Errors errors={errors} />
 
     if (!catalog || !metrics) return <div className={loader}><ContentLoader /></div>
 

--- a/src/modules/Catalogs/pages/CatalogDetail/CatalogDetail.js
+++ b/src/modules/Catalogs/pages/CatalogDetail/CatalogDetail.js
@@ -9,6 +9,7 @@ import { waitForDataAndSetState, cancelAllPromises } from '../../../../helpers/c
 // Import Shared Components
 import SearchInput from '../../../../components/SearchInput/SearchInput'
 import ContentLoader from '../../../../components/Loader/ContentLoader'
+import Errors from '../../../../components/Errors/Errors'
 
 // Import Components
 import CatalogSection from '../../components/CatalogSection/CatalogSection'

--- a/src/modules/Catalogs/pages/CatalogDetail/__test__/CatalogDetail.test.js
+++ b/src/modules/Catalogs/pages/CatalogDetail/__test__/CatalogDetail.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 
 import ContentLoader from '../../../../../components/Loader/ContentLoader'
+import Errors from '../../../../../components/Errors/Errors'
 
 import catalog from '../../../../../fetch/__test__/catalog.json'
 import metrics from '../../../../../fetch/__test__/metrics.json'
@@ -26,7 +27,7 @@ describe('<CatalogDetail />', () => {
   describe('fetch', () => {
 
     describe('updateMetrics()', () => {
-      it('Should assign metrics to this.state ', () => {
+      it('should assign metrics to this.state ', () => {
         const wrapper = shallow(<CatalogDetail params={{catalogId: '1'}} />)
 
         return wrapper
@@ -35,7 +36,7 @@ describe('<CatalogDetail />', () => {
           .then(() => expect(wrapper.state('metrics')).to.equal(metrics))
       })
 
-      it('Should add an error to this.state, catalogId is required', () => {
+      it('should add an error to this.state, catalogId is required', () => {
         const wrapper = shallow(<CatalogDetail params={{}}/>)
 
         return wrapper
@@ -44,7 +45,17 @@ describe('<CatalogDetail />', () => {
           .then(() => expect(wrapper.state('errors')).to.contain('catalogId is required'))
       })
 
-      it('Should add an error to this.state, metrics not found', () => {
+      it('should render a Errors component', () => {
+        const wrapper = shallow(<CatalogDetail params={{}}/>)
+        const errors = <Errors errors={['catalogId is required']} />
+
+        return wrapper
+          .instance()
+          .componentWillMount()
+          .then(() => expect(wrapper).to.contain(errors))
+      })
+
+      it('should add an error to this.state, metrics not found', () => {
         const wrapper = shallow(<CatalogDetail params={{catalogId: '0'}} />)
 
         return wrapper
@@ -55,7 +66,7 @@ describe('<CatalogDetail />', () => {
     })
 
     describe('updateCatalog()', () => {
-      it('Should assign catalog to this.state', () => {
+      it('should assign catalog to this.state', () => {
         const wrapper = shallow(<CatalogDetail params={{catalogId: '1'}} />)
         return wrapper
           .instance()
@@ -63,7 +74,7 @@ describe('<CatalogDetail />', () => {
           .then(() => expect(wrapper.state('catalog')).to.equal(catalog))
       })
 
-      it('Should add an error to this.state, catalogId is required', () => {
+      it('should add an error to this.state, catalogId is required', () => {
         const wrapper = shallow(<CatalogDetail params={{}}/>)
 
         return wrapper
@@ -72,7 +83,7 @@ describe('<CatalogDetail />', () => {
           .then(() => expect(wrapper.state('errors')).to.contain('catalogId is required'))
       })
 
-      it('Should add an error to this.state, catalog not found', () => {
+      it('should add an error to this.state, catalog not found', () => {
         const wrapper = shallow(<CatalogDetail params={{catalogId: '0'}} />)
 
         return wrapper
@@ -83,7 +94,7 @@ describe('<CatalogDetail />', () => {
     })
 
     describe('componentWillMount()', () => {
-      it('Should assign catalog and metrics to this.state when data is retrieved', () => {
+      it('should assign catalog and metrics to this.state when data is retrieved', () => {
         const wrapper = shallow(<CatalogDetail params={{catalogId: '1'}} />)
         return wrapper
           .instance()

--- a/src/modules/Datasets/pages/DatasetDetail/DatasetDetail.js
+++ b/src/modules/Datasets/pages/DatasetDetail/DatasetDetail.js
@@ -8,6 +8,7 @@ import DownloadDatasets from '../../components/Downloads/DownloadDatasets'
 import FiltersSection from '../../components/FiltersSection/FiltersSection'
 
 import ContentLoader from '../../../../components/Loader/ContentLoader'
+import Errors from '../../../../components/Errors/Errors'
 
 import { fetchDataset, fetchCatalogs } from '../../../../fetch/fetch'
 import { waitForDataAndSetState, cancelAllPromises } from '../../../../helpers/components'
@@ -40,7 +41,9 @@ export default class DatasetDetail extends Component {
   }
 
   render() {
-    const { dataset, catalogs } = this.state
+    const { dataset, catalogs, errors } = this.state
+
+    if (errors.length) return <Errors errors={errors} />
 
     if (!dataset || !catalogs) return <div className={loader}><ContentLoader /></div>
 

--- a/src/modules/Datasets/pages/DatasetDetail/__test__/DatasetDetail.test.js
+++ b/src/modules/Datasets/pages/DatasetDetail/__test__/DatasetDetail.test.js
@@ -1,7 +1,8 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { mount, shallow } from 'enzyme'
 
 import CircularProgress from '../../../../../components/CircularProgress/CircularProgress'
+import Errors from '../../../../../components/Errors/Errors'
 import datasetMock from '../../../../../fetch/__test__/dataset.json'
 
 const DatasetDetail = require('proxyquire')('../DatasetDetail', {
@@ -28,6 +29,18 @@ describe('<DatasetDetail />', () => {
           const titleBlock = <h1>{datasetMock.metadata.title}</h1>
           expect(wrapper.containsMatchingElement(titleBlock)).to.be.true
         })
+    })
+  })
+
+  describe('If an error occurs', () => {
+    it('should render a Errors component', () => {
+      const wrapper = shallow(<DatasetDetail params={{}}/>)
+      const errors = <Errors errors={['datasetId is required']} />
+
+      return wrapper
+        .instance()
+        .componentWillMount()
+        .then(() => expect(wrapper).to.contain(errors))
     })
   })
 


### PR DESCRIPTION
<img width="1280" alt="capture d ecran 2017-01-27 a 11 01 07" src="https://cloud.githubusercontent.com/assets/7040549/22367085/fbbf859a-e47f-11e6-995c-994fdae05a7b.png">

Fix #243 Pas d'erreur affichée à l'utilisateur en cas de 404 sur un jeu de données 