### PR TITLE
Gestion du scroll lors du routage

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "react-paginate": "^4.1.1",
     "react-responsive": "^1.1.5",
     "react-router": "^3.0.1",
+    "react-router-scroll": "^0.4.1",
     "reactable": "^0.14.1",
     "underscore.string": "^3.3.4",
     "whatwg-fetch": "^2.0.1"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { Router, Route, Redirect, IndexRoute, browserHistory } from 'react-router'
+import { Router, Route, Redirect, IndexRoute, browserHistory, applyRouterMiddleware } from 'react-router'
+import { useScroll } from 'react-router-scroll'
 import moment from 'moment'
 import createPiwikConnector from 'piwik-react-router'
 
@@ -29,9 +30,8 @@ createPiwikConnector({
   url: 'https://stats.data.gouv.fr',
   siteId: 32
 }).connectToHistory(browserHistory);
-
 ReactDOM.render((
-  <Router history={browserHistory}>
+  <Router history={browserHistory} render={applyRouterMiddleware(useScroll())}>
     <Route path="/" component={App}>
       <IndexRoute component={Home} />
       <Route path="/events" component={Events} />

--- a/src/modules/Datasets/components/Datasets/Datasets.js
+++ b/src/modules/Datasets/components/Datasets/Datasets.js
@@ -58,7 +58,6 @@ class Datasets extends Component {
   }
 
   search(changes = {}, pushToHistory = true) {
-    window.scrollTo(0, 0);
     return this.setState(changes, () => {
       if (pushToHistory) this.pushToHistory()
       return this.fetchRecords()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1615,6 +1615,10 @@ dom-converter@~0.1:
   dependencies:
     utila "~0.3"
 
+dom-helpers@^3.0.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
+
 dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
@@ -4497,6 +4501,13 @@ react-responsive@^1.1.5:
     hyphenate-style-name "^1.0.0"
     matchmedia "^0.1.2"
 
+react-router-scroll@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/react-router-scroll/-/react-router-scroll-0.4.1.tgz#8cafd348d34e54b1127ec0fb7f8323d0d4c489e0"
+  dependencies:
+    scroll-behavior "^0.9.1"
+    warning "^3.0.0"
+
 react-router@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.0.2.tgz#5a19156678810e01d81901f9c0fef63284b8a514"
@@ -4781,6 +4792,13 @@ rx-lite@^3.1.2:
 sax@^1.2.1, sax@~1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
+
+scroll-behavior@^0.9.1:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/scroll-behavior/-/scroll-behavior-0.9.2.tgz#5c04648b1bd8bb14306410a97de3948c72ee1618"
+  dependencies:
+    dom-helpers "^3.0.0"
+    invariant "^2.2.1"
 
 semver@~5.3.0:
   version "5.3.0"


### PR DESCRIPTION
On scroll en haut de la page à chaque changement de page.

Un retour page précédent (commande navigateur) donne [une position un peu erratique](https://github.com/taion/react-router-scroll/pull/59), à améliorer par la suite.

Surcharge du bundle : +2 Ko min+gzip