### PR TITLE
Seul la première lettre des filtres est majuscule

### DIFF
--- a/src/components/Facets/FacetsGroup.css
+++ b/src/components/Facets/FacetsGroup.css
@@ -8,6 +8,10 @@
   margin-bottom: 1em;
 }
 
+.container h4:first-letter {
+  text-transform: uppercase;
+}
+
 @media (max-width: 768px) {
   .container {
     display: none;

--- a/src/components/Filter/Filter.css
+++ b/src/components/Filter/Filter.css
@@ -1,7 +1,6 @@
 @import "../../theme/colors";
 
 .link {
-  text-transform: capitalize;
   position: relative;
   padding: .4em .5em;
   margin: 2px 2px 2px 0;
@@ -15,6 +14,10 @@
   max-width: 200px;
   overflow: hidden;
   border: none;
+}
+
+.link::first-letter {
+  text-transform: uppercase;
 }
 
 .link:hover {

--- a/src/components/Filter/Filter.css
+++ b/src/components/Filter/Filter.css
@@ -9,15 +9,24 @@
   text-align: center;
   color: var(--blue);
   background-color: var(--lightestblue);
-  text-overflow: ellipsis;
   font-size: 12px;
-  max-width: 200px;
   overflow: hidden;
   border: none;
 }
 
-.link::first-letter {
+.link span {
+  display: table-cell;
+}
+
+.link span::first-letter {
   text-transform: uppercase;
+}
+
+.filterValue {
+  padding-left: 5px;
+  text-overflow: ellipsis;
+  max-width: 200px;
+  overflow: hidden;
 }
 
 .link:hover {

--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { translateFilters } from '../../helpers/manageFilters'
 
-import { link } from './Filter.css'
+import { link, filterValue } from './Filter.css'
 
 const Filter = (props) => {
   const { detail, remove, filter, style, onClick } = props
@@ -11,7 +11,7 @@ const Filter = (props) => {
 
   return (
     <button className={link} title={`${title}: ${value}`} style={style} onClick={() => onClick && onClick(filter)}>
-      { detail && `${title}: ` }{value}
+      <span>{ detail && `${title}:` }</span><span className={filterValue}>{value}</span>
       { remove && <span>&nbsp;<i className="fa fa-close" /></span>}
     </button>
   )

--- a/src/helpers/__test__/manageFilters.test.js
+++ b/src/helpers/__test__/manageFilters.test.js
@@ -6,7 +6,7 @@ describe('manageFilters', () => {
     describe('Known filter', () => {
       it('should translate filter', () => {
         const filter = 'availability'
-        expect(translateFilters(filter)).to.equal('Téléchargeable')
+        expect(translateFilters(filter)).to.equal('téléchargeable')
       })
     })
 

--- a/src/helpers/manageFilters.js
+++ b/src/helpers/manageFilters.js
@@ -1,22 +1,22 @@
 import { remove, unionWith, find, isEqual, some } from 'lodash'
 
 export const filterTradTable = {
-  availability: 'Téléchargeable',
-  dgvPublication: 'Publié sur data.gouv.fr',
-  distributionFormat: 'Format de distribution',
-  keyword: 'Mot-clé',
-  metadataType: 'Type de metadonnée',
-  opendata: 'Donnée ouverte',
-  organization: 'Organisation',
-  representationType: 'Type géographique',
-  type: 'Type',
-  catalog: 'Catalogue',
-  yes: 'Oui',
-  no: 'Non',
-  'not-determined': 'Non déterminé',
-  other: 'Autre',
-  unknown: 'Inconnu',
-  none: 'Aucun',
+  availability: 'téléchargeable',
+  dgvPublication: 'publié sur data.gouv.fr',
+  distributionFormat: 'format de distribution',
+  keyword: 'mot-clé',
+  metadataType: 'type de metadonnée',
+  opendata: 'donnée ouverte',
+  organization: 'organisation',
+  representationType: 'type géographique',
+  type: 'type',
+  catalog: 'catalogue',
+  yes: 'oui',
+  no: 'non',
+  'not-determined': 'non déterminé',
+  other: 'autre',
+  unknown: 'inconnu',
+  none: 'aucun',
 }
 
 export function translateFilters(filter) {


### PR DESCRIPTION
L'utilisation de `text-transform: uppercase;` remplacé toutes les premières lettre de chaque mot. Maintenant corrigé par `::first-letter`