### PR TITLE
Remplace les widgets Eventbrite par un lien vers la page Évènements

### DIFF
--- a/src/components/Home/Home.css
+++ b/src/components/Home/Home.css
@@ -88,14 +88,13 @@
   }
 }
 
-.events {
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
+.events a {
+  color: #fff;
 }
 
-.events iframe {
-  margin: 1em;
+.events a:hover {
+  color: #fff;
+  text-decoration: underline;
 }
 
 .catalogs {

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import { browserHistory, Link } from 'react-router'
 
-import EventbriteWidget from '../Event/EventbriteWidget'
 import SearchInput from '../SearchInput/SearchInput'
 import CatalogPreview from '../CatalogPreview/CatalogPreview'
 
@@ -156,8 +155,7 @@ class Home extends Component {
 
             <h2 id="evenements">Événements à venir</h2>
             <div className={events}>
-              <EventbriteWidget src="https://www.eventbrite.fr/countdown-widget?eid=31508534876"/>
-              <EventbriteWidget src="https://www.eventbrite.fr/countdown-widget?eid=32256259340"/>
+              <Link to="events">Voir nos prochains évènements</Link>
             </div>
           </div>
         </div>


### PR DESCRIPTION

<img width="1280" alt="capture d ecran 2017-03-07 a 16 46 53" src="https://cloud.githubusercontent.com/assets/7040549/23664383/b41eb252-0355-11e7-8822-6ce50c86567d.png">


Fix #318 Ne plus afficher les cartes Événements en page d'accueil