### PR TITLE
Corrige le problème d'affichage des liens sur mobile

### DIFF
--- a/src/modules/Datasets/components/LinksSection/LinksSection.css
+++ b/src/modules/Datasets/components/LinksSection/LinksSection.css
@@ -1,3 +1,9 @@
+.linkList {
+  white-space: normal;
+  overflow: hidden;
+  text-overflow: clip;
+}
+
 .linkList a:hover {
   text-decoration: underline;
 }


### PR DESCRIPTION
De cette façon l'overflow des liens trop grand et qui ne retournent pas à la ligne (toujours pour une raison inconnu) disparait. Les autres en revanche retournent toujours à la ligne.

<img width="527" alt="capture d ecran 2017-03-31 a 14 01 10" src="https://cloud.githubusercontent.com/assets/7040549/24549670/b1d62002-161a-11e7-8280-6d52f5e149ab.png">

Fix #370 Problème d'affichage des liens en version mobile