### PR TITLE
[WIP] Permet d'écrire sur l'API data.gouv.fr en mode développement

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -1,7 +1,7 @@
 // Grab NODE_ENV and REACT_APP_* environment variables and prepare them to be
 // injected into the application via DefinePlugin in Webpack configuration.
 
-var REACT_APP = /^REACT_APP_/i;
+var REACT_APP = /^INSPIRE_/i;
 
 function getClientEnvironment(publicUrl) {
   return Object

--- a/src/fetch/fetch.js
+++ b/src/fetch/fetch.js
@@ -147,14 +147,14 @@ export function getDataGouvPublication(datasetId) {
 // DATA.GOUV.FR
 export function getDatasetOnDataGouv(datasetId) {
   if (!datasetId) return Promise.reject(new Error('datasetId is required'))
-  const url = `https://www.data.gouv.fr/api/1/datasets/${datasetId}/`
+  const url = `https://inspire.data.gouv.fr/dgv/proxy-api/1/datasets/${datasetId}/`
 
   return _get(url)
 }
 
 export function getDiscussions(datasetId) {
   if (!datasetId) return Promise.reject(new Error('datasetId is required'))
-  const url = `https://www.data.gouv.fr/api/1/discussions/?for=${datasetId}`
+  const url = `https://inspire.data.gouv.fr/dgv/proxy-api/1/discussions/?for=${datasetId}`
 
   return _get(url)
 }

--- a/src/helpers/super.js
+++ b/src/helpers/super.js
@@ -1,3 +1,7 @@
+const overrideDataGouvApiUrl = process.env.INSPIRE_DATAGOUV_API_URL || 'https://next.data.gouv.fr/api'
+const dataGouvApiKey = process.env.INSPIRE_DATAGOUV_API_KEY
+
+
 export function _fetch(url, method, data) {
   const options = {
     headers: {
@@ -9,6 +13,16 @@ export function _fetch(url, method, data) {
 
   if (url.includes('https://inspire.data.gouv.fr/dgv/api')) {
     options.credentials = 'include'
+  }
+
+  if (url.includes('https://inspire.data.gouv.fr/dgv/proxy-api')) {
+    if (dataGouvApiKey) {
+      url = url.replace('https://inspire.data.gouv.fr/dgv/proxy-api', overrideDataGouvApiUrl)
+      options.headers['X-API-KEY'] = dataGouvApiKey
+      options.mode = undefined
+    } else {
+      options.credentials = 'include'
+    }
   }
 
   if (data) {


### PR DESCRIPTION
Pour utiliser, il suffit de définir la variable d'environnement `INSPIRE_DATAGOUV_API_KEY` avec son jeton personnel sur data.gouv.fr.
Par défaut il faut utiliser un jeton issu de next.data.gouv.fr.

Exemple :
```bash
INSPIRE_DATAGOUV_API_KEY=monjeton yarn start
```