### PR TITLE
Corrige l'alignement du titre du thème Inspire

### DIFF
--- a/src/modules/Datasets/components/DatasetSection/DatasetSection.css
+++ b/src/modules/Datasets/components/DatasetSection/DatasetSection.css
@@ -56,7 +56,6 @@
 .inspireThemeHead img {
   width: 80px;
   height: 80px;
-  margin-right: 2em;
   padding: 0.3em;
   border-radius: 60px;
   background-color: #fff;
@@ -107,7 +106,6 @@
   .inspireThemeHead img {
     width: 50px;
     height: 50px;
-    margin-right: 2em;
     border-radius: 60px;
     padding: 0.3em;
     background-color: #fff;


### PR DESCRIPTION
# Avant
<img width="829" alt="capture d ecran 2017-04-05 a 16 45 46" src="https://cloud.githubusercontent.com/assets/7040549/24711210/95033e52-1a1f-11e7-81a3-25a3b36a82ff.png">

# Après
<img width="829" alt="capture d ecran 2017-04-05 a 16 45 22" src="https://cloud.githubusercontent.com/assets/7040549/24711212/9634f1ee-1a1f-11e7-8c45-50fbba8e812f.png">
