### PR TITLE
Ajout d'un robots.txt minimal

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /api/
+Disallow: /dgv/


### PR DESCRIPTION
Pour que les robots ne s'amusent plus à crawler l'outil d'extraction et les APIs en général.