### PR TITLE
Pin react-router to 3.0.3 to avoid npm install failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "react-leaflet": "^1.1.1",
     "react-paginate": "^4.1.1",
     "react-responsive": "^1.1.5",
-    "react-router": "^3.0.1",
+    "react-router": "3.0.3",
     "react-router-scroll": "^0.4.1",
     "react-sticky": "^5.0.5",
     "reactable": "^0.14.1",


### PR DESCRIPTION
This way we benefit both from yarn and npm install.
`npm@5` lockfile is provided too.

For reference, with `react-router@3.0.5`, frontend fails to load.

fix #395 