### PR TITLE
Fix search, overall

### DIFF
--- a/src/components/SearchInput/SearchInput.js
+++ b/src/components/SearchInput/SearchInput.js
@@ -1,45 +1,27 @@
-import React, { Component } from 'react'
+import React, { PureComponent } from 'react'
 import { wrapper, input, button } from './SearchInput.css'
 
-class SearchInput extends Component {
-  constructor(props) {
-    super(props)
-    this.state = { textInput: props.textInput || '' }
-  }
+class SearchInput extends PureComponent {
+  onSubmit(event) {
+    event.preventDefault();
 
-  componentWillReceiveProps(nextProps) {
-    if (!nextProps.textInput || this.props.textInput === nextProps.textInput) return
-    this.setState({ textInput: nextProps.textInput })
-  }
-
-  onChange(event) {
-    this.setState({textInput: event.target.value});
-  }
-
-  onKeyPress(event) {
-    if (event.key === 'Enter') {
-      this.props.onSearch(this.state.textInput)
-    }
-  }
-
-  search() {
-    this.props.onSearch(this.state.textInput)
+    this.props.onSearch(event.target.query.value);
   }
 
   render() {
-    const { placeholder } = this.props
+    const { placeholder, textInput } = this.props
 
     return (
-      <div className={wrapper}>
+      <form onSubmit={e => this.onSubmit(e)} className={wrapper}>
         <input
           type='text'
-          value={this.state.textInput}
+          name='query'
+          value={textInput}
           className={input}
-          onChange={e => this.onChange(e)}
-          onKeyPress={e => this.onKeyPress(e)}
-          placeholder={placeholder ? placeholder : 'Rechercher...'} />
-        {this.props.searchButton ? <button className={button} onClick={() => this.search()}>Rechercher</button> : undefined}
-      </div>
+          placeholder={placeholder ? placeholder : 'Rechercher…'} />
+
+        {this.props.searchButton ? <button type='submit' className={button}>Rechercher</button> : undefined}
+      </form>
     )
   }
 }

--- a/src/modules/Datasets/components/Datasets/Datasets.js
+++ b/src/modules/Datasets/components/Datasets/Datasets.js
@@ -1,106 +1,98 @@
-import React, { Component } from 'react'
-import { browserHistory } from 'react-router'
-import qs from 'qs'
+import React, { PureComponent } from 'react'
 
 import DatasetsResults from '../DatasetsResults/DatasetsResults'
 import SearchInput from '../../../../components/SearchInput/SearchInput'
 import Filter from '../../../../components/Filter/Filter'
 
 import { search } from '../../../../fetch/fetch'
-import { convertFilters } from '../../../../helpers/manageFilters'
 import { waitForDataAndSetState, cancelAllPromises } from '../../../../helpers/components'
 import { addFilter, removeFilter } from '../../../../helpers/manageFilters'
 
 import style from './Datasets.css'
 
 
-export function buildSearchQuery(q, filters, page) {
-  const qsFilters = convertFilters(filters)
-  const qPart = (q && q.length) ? { q } : {}
-  const pagePart = (page && page > 1) ? { page } : {}
-  return qs.stringify({ ...qPart, ...pagePart, ...qsFilters }, { indices: false })
-}
-
-class Datasets extends Component {
+class Datasets extends PureComponent {
   constructor(props) {
     super(props)
     this.state = {
-      errors: [],
-      ...props.query
+      errors: []
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (!nextProps.query || this.props.query === nextProps.query) return
-    this.search(nextProps.query, false)
-  }
-
   componentDidMount() {
-    return this.fetchRecords()
+    const { textInput, filters, page = 1 } = this.props.query
+
+    let allFilters = filters
+    const offset = (page - 1) * 20
+    return waitForDataAndSetState(search(textInput, allFilters, offset), this, 'datasets')
   }
 
   componentWillUnmount() {
     return cancelAllPromises(this)
   }
 
-  fetchRecords() {
-    const { textInput, filters, page = 1 } = this.state
-    let allFilters = filters
-    const offset = (page - 1) * 20
-    return waitForDataAndSetState(search(textInput, allFilters, offset), this, 'datasets')
-  }
+  addFilter(filter) {
+    const {
+      query,
+      updateQuery
+    } = this.props
 
-  pushToHistory() {
-    let { textInput, filters, page } = this.state
-    const query = buildSearchQuery(textInput, filters, page)
-    if (window.location.search === `?${query}`) return
-    browserHistory.push('/search?' + query)
-  }
-
-  search(changes = {}, pushToHistory = true) {
-    return this.setState(changes, () => {
-      if (pushToHistory) this.pushToHistory()
-      return this.fetchRecords()
+    updateQuery({
+      filters: addFilter(query.filters, filter),
+      page: 1
     })
   }
 
-  addFilter(filter) {
-    const filters = addFilter(this.state.filters, filter)
-    return this.search({ filters, page: 1, datasets: null })
-  }
-
   removeFilter(filter) {
-    const filters = removeFilter(this.state.filters, filter)
-    return this.search({ filters, page: 1, datasets: null })
+    const {
+      query,
+      updateQuery
+    } = this.props
+
+    updateQuery({
+      filters: removeFilter(query.filters, filter),
+      page: 1
+    })
   }
 
   userSearch(textInput) {
-    return this.search({ textInput, datasets: null, page: 1 })
+    return this.props.updateQuery({ textInput, page: 1 })
   }
 
   handleChangePage({ selected }) {
-    return this.search({ page: selected + 1 })
+    const {
+      query,
+      updateQuery
+    } = this.props
+
+    const page = selected + 1
+
+    if (query.page !== page) {
+      updateQuery({ page })
+    }
   }
 
   render() {
-    const { textInput, filters, datasets, page, errors } = this.state
+    const { query } = this.props
+    const { datasets, errors } = this.state
+
     return (
       <div>
         <div className={style.searchWrapper}>
           <SearchInput
-            textInput={textInput}
-            filters={filters}
+            textInput={query.textInput}
+            filters={query.filters}
             searchButton={true}
             onSearch={(textInput) => this.userSearch(textInput)} />
 
-          <div className={style.filters}>{filters.length ? 'Filtres actifs' : 'Aucun filtre actif'}</div>
-          {filters.map((filter, idx) => <Filter detail={true} remove={true} key={idx} filter={filter} onClick={(filter) => this.removeFilter(filter)} />)}
+          <div className={style.filters}>{query.filters.length ? 'Filtres actifs' : 'Aucun filtre actif'}</div>
+          {query.filters.map((filter, idx) => <Filter detail={true} remove={true} key={idx} filter={filter} onClick={(filter) => this.removeFilter(filter)} />)}
         </div>
 
         <DatasetsResults
           datasets={datasets}
-          filters={filters}
-          page={page}
+          filters={query.filters}
+          page={query.page}
           addFilter={(filter) => this.addFilter(filter)}
           handleChangePage={(data) => this.handleChangePage(data)}
           errors={errors}/>

--- a/src/modules/Datasets/pages/WrappedDatasets/__test__/WrappedDatasets.test.js
+++ b/src/modules/Datasets/pages/WrappedDatasets/__test__/WrappedDatasets.test.js
@@ -1,4 +1,13 @@
-import { parseQuery, _extractFilters } from '../WrappedDatasets'
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import { parseQuery, _extractFilters, buildSearchQuery } from '../WrappedDatasets'
+
+const WrappedDatasets = require('proxyquire')('../WrappedDatasets', {
+  'react-router': {
+    browserHistory: {push:  () => {}}
+  }
+}).default
 
 describe('_extractFilters', () => {
   it('should return filters array', () => {
@@ -55,5 +64,55 @@ describe('parseQuery', () => {
         ],
       }
     )
+  })
+})
+
+describe('buildSearchQuery()', () => {
+  it('should return a query', () => {
+    const componentState = {
+      textInput: '42',
+      page: 2,
+      filters: [
+        {name: 'keywords', value: 'keyword1'},
+        {name: 'keywords', value: 'keyword2'},
+        {name: 'organizations', value: 'foo'},
+      ],
+    }
+    const expectedUrl = 'q=42&page=2&keywords=keyword1&keywords=keyword2&organizations=foo'
+    const builQuery = buildSearchQuery(
+      componentState.textInput,
+      componentState.filters,
+      componentState.page,
+    )
+    expect(builQuery).to.equal(expectedUrl)
+  })
+})
+
+describe('<WrappedDatasets />', () => {
+
+  let wrapper
+  beforeEach(() => {
+    const location = {
+      query: {
+        textInput: 'text',
+        page: 2,
+        filters: [{name: 'filter1', value: 'value1'}],
+      }
+    }
+    wrapper = shallow(<WrappedDatasets pathname={'pathname'} location={location} />)
+  })
+
+  describe('updateQuery()', () => {
+    it('should update the query', () => {
+      wrapper.instance().updateQuery({
+        textInput: 'text new',
+        page: 3,
+        filters: [{name: 'filter2', value: 'value2'}],
+      })
+
+      expect(wrapper.state('textInput')).to.equal('text new')
+      expect(wrapper.state('page')).to.equal(3)
+      expect(wrapper.state('filters')).to.deep.equal([{name: 'filter2', value: 'value2'}])
+    })
   })
 })


### PR DESCRIPTION
There were a couple issues with the search mechanism:
* Almost all components down the search line would save and duplicate some part of the search state.
* This lead to race conditions and state mismatches between components, so it would be impossible to change a search query without reloading the page completely.

Basically, this [*lifts the state up*][1] all the way to the WrappedDataset component.

WrappedDataset holds the query state, Dataset pushes updates to WrappedDataset’s state and SearchInput’s input is no longer a controlled input.

I also changed the SearchInput to use a form instead of keyUp hooks for submitting, as it’s how it’s done in HTML.

[1]: https://facebook.github.io/react/docs/lifting-state-up.html