### PR TITLE
Deploy when publishing new tags instead of master

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,8 @@ test:
 
 deployment:
   production:
-    branch: master
+    tag: /v[0-9]+(\.[0-9]+)*/
+    owner: etalab
     commands:
       - git config --global user.email "infra@beta.gouv.fr"
       - git config --global user.name "CircleCI"


### PR DESCRIPTION
This will deploy only when publishing semver tags (e.g.: v2.1.0) instead of deploying every time we push to master.

See https://circleci.com/docs/1.0/configuration/