### PR TITLE
Hide empty collections from the dataset page

### DIFF
--- a/src/routes/Dataset/components/DatasetFilters/DatasetFilters.js
+++ b/src/routes/Dataset/components/DatasetFilters/DatasetFilters.js
@@ -21,7 +21,7 @@ const DatasetFilters = ({ organizations, keywords }) => {
 
   return (
     <div>
-      {sections.map(section => (
+      {sections.map(section => section.filters.length > 0 && (
         <div key={section.title} className={styles.group}>
           <h4>{section.title}</h4>
           <div className={styles.facets}>

--- a/src/routes/Dataset/components/DatasetView/DatasetView.js
+++ b/src/routes/Dataset/components/DatasetView/DatasetView.js
@@ -110,12 +110,14 @@ class DatasetView extends React.PureComponent {
                   </DatasetBlock>
                 )}
 
-                <DatasetBlock title='Filtres'>
-                  <DatasetFilters
-                    keywords={dataset.metadata.keywords}
-                    organizations={dataset.organizations}
-                  />
-                </DatasetBlock>
+                {(dataset.metadata.keywords.length > 0 || dataset.organizations.length > 0) && (
+                  <DatasetBlock title='Filtres'>
+                    <DatasetFilters
+                      keywords={dataset.metadata.keywords}
+                      organizations={dataset.organizations}
+                    />
+                  </DatasetBlock>
+                )}
               </div>
 
               <div className={styles.aside}>

--- a/src/routes/Dataset/components/DatasetView/DatasetView.js
+++ b/src/routes/Dataset/components/DatasetView/DatasetView.js
@@ -145,9 +145,11 @@ class DatasetView extends React.PureComponent {
                   <DatasetDataGouvPublication dataset={dataset} publication={publication} />
                 </DatasetBlock>
 
-                <DatasetBlock title='Contacts'>
-                  <DatasetContactList contacts={dataset.metadata.contacts} />
-                </DatasetBlock>
+                {dataset.metadata.contacts.length > 0 && (
+                  <DatasetBlock title='Contacts'>
+                    <DatasetContactList contacts={dataset.metadata.contacts} />
+                  </DatasetBlock>
+                )}
 
                 {dataset.metadata.credit && (
                   <DatasetBlock title='Contributions'>

--- a/src/routes/Dataset/components/DatasetView/DatasetView.js
+++ b/src/routes/Dataset/components/DatasetView/DatasetView.js
@@ -96,13 +96,11 @@ class DatasetView extends React.PureComponent {
                   )}
                 </DatasetBlock>
 
-                <DatasetBlock title='Liens'>
-                  {dataset.metadata.links.length > 0 ? (
+                {dataset.metadata.links.length > 0 && (
+                  <DatasetBlock title='Liens'>
                     <DatasetLinks links={dataset.metadata.links} />
-                  ) : (
-                    <div>Aucun lien disponible.</div>
-                  )}
-                </DatasetBlock>
+                  </DatasetBlock>
+                )}
 
                 {publication && publication.remoteId && (
                   <DatasetBlock title='Discussions'>


### PR DESCRIPTION
- Contact block doesn’t show an empty block when there are no contacts available anymore.

- Filters don’t show when not available and global filter block doesn’t show when all of the child filter lists are empty.

- Hide Link block when no links are available. I think that the most relevant block to show is the “Downloads” block – we’re keeping it even when there are no downloads available with a little message that says ”Nothing to download” (yet).
  But I don’t believe that the Link block is that important (when empty).
  What do you think @tmerlier, @jdesboeufs?