### PR TITLE
Split publication route out of the main bundle

### DIFF
--- a/src/routes/Publication/index.js
+++ b/src/routes/Publication/index.js
@@ -1,27 +1,50 @@
-import Publication from 'common/modules/Publication/pages/Publication/Publication'
-import Organization from 'common/modules/Publication/pages/Organization/Organization'
-import PublishingDatasets from 'common/modules/Publication/pages/PublishingDatasets/PublishingDatasets'
-import OrganizationProducers from 'common/modules/Publication/pages/OrganizationProducers/OrganizationProducers'
-
 export default () => ({
   path: 'publication',
 
   indexRoute: {
-    component: Publication
+    async getComponent(nextState, cb) {
+      const Publication = await import(
+        /* webpackChunkName: 'publication' */
+        'common/modules/Publication/pages/Publication/Publication'
+      )
+
+      cb(null, Publication.default)
+    }
   },
 
   childRoutes: [
     {
       path: ':organizationId',
-      component: Organization
+      async getComponent(nextState, cb) {
+        const Organization = await import(
+          /* webpackChunkName: 'publication' */
+          'common/modules/Publication/pages/Organization/Organization'
+        )
+
+        cb(null, Organization.default)
+      }
     },
     {
       path: ':organizationId/datasets',
-      component: PublishingDatasets
+      async getComponent(nextState, cb) {
+        const PublishingDatasets = await import(
+          /* webpackChunkName: 'publication' */
+          'common/modules/Publication/pages/PublishingDatasets/PublishingDatasets'
+        )
+
+        cb(null, PublishingDatasets.default)
+      }
     },
     {
       path: ':organizationId/producers',
-      component: OrganizationProducers
+      async getComponent(nextState, cb) {
+        const OrganizationProducers = await import(
+          /* webpackChunkName: 'publication' */
+          'common/modules/Publication/pages/OrganizationProducers/OrganizationProducers'
+        )
+
+        cb(null, OrganizationProducers.default)
+      }
     }
   ]
 })


### PR DESCRIPTION
Reduce the initial bundle sizes for more than 9KB gzipped.

```
File sizes after gzip:

  dist/scripts/vendor.js               178.76 KB (- 293 B)
  dist/scripts/app.js                  15.45 KB (- 8.71 KB)
  dist/scripts/modules/dataset.js      12.72 KB (+ 9 B)
  dist/styles/app.css                  9.04 KB
  dist/scripts/modules/publication.js  8.64 KB
  dist/scripts/modules/catalogs.js     6.81 KB (+ 4 B)
  dist/scripts/modules/search.js       4.95 KB (+ 10 B)
  dist/scripts/modules/common.js       2.9 KB (+ 619 B)
  dist/index.html                      1.26 KB
  dist/scripts/manifest.js             1018 B (+ 27 B)
  dist/scripts/modules/events.js       903 B (+ 2 B)

  TOTAL                                242.41 KB (+ 313 B)
```