### PR TITLE
Make sure that all available languages are loaded

### DIFF
--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -2,6 +2,11 @@ import i18next from 'i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 import moment from 'moment'
 
+const availableLanguages = [
+  'en',
+  'fr'
+]
+
 export default () => {
   const i18n = i18next
     .use(LanguageDetector)
@@ -16,8 +21,7 @@ export default () => {
       },
 
       whitelist: [
-        'en',
-        'fr'
+        ...availableLanguages
       ],
 
       fallbackLng: 'en',
@@ -33,6 +37,7 @@ export default () => {
       }
     })
 
+  i18n.availableLanguages = availableLanguages
   moment.locale(i18n.language)
 
   return i18n

--- a/src/routes/Catalogs/routes/Catalog/index.js
+++ b/src/routes/Catalogs/routes/Catalog/index.js
@@ -13,7 +13,7 @@ export default (store, i18n) => ({
       reducer: catalog.reducer
     })
 
-    i18n.languages.forEach(async lang => {
+    i18n.availableLanguages.forEach(async lang => {
       injectLocale(i18n, {
         locale: lang,
         namespace: 'Catalogs.Catalog',

--- a/src/routes/Catalogs/routes/CatalogHarvest/index.js
+++ b/src/routes/Catalogs/routes/CatalogHarvest/index.js
@@ -13,7 +13,7 @@ export default (store, i18n) => ({
       reducer: catalog.reducer
     })
 
-    i18n.languages.forEach(async lang => {
+    i18n.availableLanguages.forEach(async lang => {
       injectLocale(i18n, {
         locale: lang,
         namespace: 'Catalogs.CatalogHarvest',

--- a/src/routes/Catalogs/routes/CatalogsList/index.js
+++ b/src/routes/Catalogs/routes/CatalogsList/index.js
@@ -11,7 +11,7 @@ export default (store, i18n) => ({
       reducer: catalogs.reducer
     })
 
-    i18n.languages.forEach(async lang => {
+    i18n.availableLanguages.forEach(async lang => {
       injectLocale(i18n, {
         locale: lang,
         namespace: 'Catalogs.CatalogsList',

--- a/src/routes/Home/index.js
+++ b/src/routes/Home/index.js
@@ -4,7 +4,7 @@ import HomeContainer from './containers/HomeContainer'
 
 export default (store, i18n) => ({
   getComponent(nextState, cb) {
-    i18n.languages.forEach(lang => {
+    i18n.availableLanguages.forEach(lang => {
       injectLocale(i18n, {
         locale: lang,
         namespace: 'Home',

--- a/src/routes/NotFound/index.js
+++ b/src/routes/NotFound/index.js
@@ -6,7 +6,7 @@ export default (store, i18n) => ({
   path: '*',
 
   getComponent(nextState, cb) {
-    i18n.languages.forEach(lang => {
+    i18n.availableLanguages.forEach(lang => {
       injectLocale(i18n, {
         locale: lang,
         namespace: 'NotFound',


### PR DESCRIPTION
On initial load (when i18nextLng is not set in localStorage), only the `en` lang was available in `i18n.languages`, so the components would not have the `fr` strings when switching to French.