### PR TITLE
Pull CI reports from current branch or master only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,9 +85,8 @@ jobs:
       - restore_cache:
           name: Restore reports cache
           keys:
-            - v1-geodatagouv-reports-{{ .Branch }}-{{ .Revision }}
             - v1-geodatagouv-reports-{{ .Branch }}-
-            - v1-geodatagouv-reports-
+            - v1-geodatagouv-reports-master-
 
       - run:
           name: Build output bundles


### PR DESCRIPTION
Stop pulling reports from random branches if there is no reports cache for the current branch as the diff would be irrelevant.

We either take the reports from the last build on the branch or the last build on master. If there is none available (which will happen only if the cache is cleared), we won’t be displaying the diff.

Also remove the over specific branch-commit pull as it can never happen.