### PR TITLE
Fix code coverage

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,6 +10,11 @@
       "plugins": [
         "transform-react-remove-prop-types"
       ]
+    },
+    "test": {
+      "plugins": [
+        "istanbul"
+      ]
     }
   }
 }

--- a/build/tests/bootstrap.js
+++ b/build/tests/bootstrap.js
@@ -1,36 +1,16 @@
-const { JSDOM } = require('jsdom')
-const moduleAlias = require('module-alias')
-const path = require('path')
+import 'jsdom-global/register'
+import 'ignore-styles'
 
-require('babel-register')()
+import moduleAlias from 'module-alias'
+import path from 'path'
+
+import chai from 'chai'
+import chaiEnzyme from 'chai-enzyme'
 
 moduleAlias.addAlias('common', path.join(__dirname, '../../src'))
 
-// Remove the PUBLIC_URL, if defined
 process.env.PUBLIC_URL = ''
-
 process.env.INSPIRE_API_URL = 'inspire-api-url'
-
-const jsdom = new JSDOM('<!doctype html><html><body></body></html>')
-const exposedProperties = ['window', 'navigator', 'document']
-
-global.window = jsdom.window
-global.document = global.window.document
-
-Object.keys(document.defaultView).forEach((property) => {
-  if (typeof global[property] === 'undefined') {
-    exposedProperties.push(property)
-    global[property] = document.defaultView[property]
-  }
-})
-
-global.navigator = window.navigator = {
-  userAgent: 'node.js',
-  platform: 'node.js',
-}
-
-const chai = require('chai')
-const chaiEnzyme = require('chai-enzyme')
 
 global.expect = chai.expect
 chai.use(chaiEnzyme())

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "start": "node build/scripts/start",
     "compile": "node build/scripts/compile",
     "build": "npm run clean && cross-env NODE_ENV=production npm run compile",
-    "test": "cross-env NODE_ENV=test mocha -r build/tests/bootstrap.js -r ignore-styles src/**/*.test.js",
-    "test:ci": "cross-env NODE_ENV=test MOCHA_FILE=reports/tests/geodatagouv/results.xml nyc mocha -r build/tests/bootstrap.js -r ignore-styles --reporter mocha-circleci-reporter src/**/*.test.js",
+    "test": "cross-env NODE_ENV=test mocha -r babel-register -r build/tests/bootstrap.js src/**/*.test.js",
+    "test:ci": "cross-env NODE_ENV=test MOCHA_FILE=reports/tests/geodatagouv/results.xml nyc mocha -r build/tests/bootstrap.js --reporter mocha-circleci-reporter src/**/*.test.js",
     "codecov": "codecov",
     "deploy": "gh-pages -d dist",
     "lint": "npm run lint:scripts && npm run lint:styles",
@@ -20,6 +20,7 @@
     "babel-core": "^6.14.0",
     "babel-eslint": "^7.0.0",
     "babel-loader": "^7.1.1",
+    "babel-plugin-istanbul": "^4.1.4",
     "babel-plugin-lodash": "^3.2.11",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.8",
     "babel-preset-react-app": "^3.0.1",
@@ -58,6 +59,7 @@
     "http-proxy-middleware": "^0.17.1",
     "ignore-styles": "^5.0.1",
     "jsdom": "^11.1.0",
+    "jsdom-global": "^3.0.2",
     "mkdirp": "^0.5.1",
     "mocha": "^3.5.0",
     "mocha-circleci-reporter": "^0.0.2",
@@ -112,14 +114,13 @@
     "node": "8.x"
   },
   "nyc": {
+    "require": [
+      "babel-register"
+    ],
+    "include": [
+      "src"
+    ],
     "exclude": [
-      "build",
-      "coverage",
-      "dist",
-      "node_modules",
-      "public",
-      "reports",
-      "server",
       "**/__test__/**",
       "**/__mocks__/**"
     ],
@@ -128,6 +129,8 @@
       "text-summary"
     ],
     "all": true,
+    "sourceMap": false,
+    "instrument": false,
     "cache": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -501,6 +501,14 @@ babel-plugin-dynamic-import-node@1.0.2:
     babel-template "^6.24.1"
     babel-types "^6.24.1"
 
+babel-plugin-istanbul@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz#18dde84bf3ce329fddf3f4103fae921456d8e587"
+  dependencies:
+    find-up "^2.1.0"
+    istanbul-lib-instrument "^1.7.2"
+    test-exclude "^4.1.1"
+
 babel-plugin-lodash@^3.2.11:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/babel-plugin-lodash/-/babel-plugin-lodash-3.2.11.tgz#21c8fdec9fe1835efaa737873e3902bdd66d5701"
@@ -3463,7 +3471,7 @@ istanbul-lib-hook@^1.0.7:
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.7.4:
+istanbul-lib-instrument@^1.7.2, istanbul-lib-instrument@^1.7.4:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.4.tgz#e9fd920e4767f3d19edc765e2d6b3f5ccbd0eea8"
   dependencies:
@@ -3536,6 +3544,10 @@ jsbn@~0.1.0:
 jschardet@^1.4.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.5.0.tgz#a61f310306a5a71188e1b1acd08add3cfbb08b1e"
+
+jsdom-global@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/jsdom-global/-/jsdom-global-3.0.2.tgz#6bd299c13b0c4626b2da2c0393cd4385d606acb9"
 
 jsdom@^11.1.0:
   version "11.1.0"


### PR DESCRIPTION
Use jsdom-global instead of custom jsdom options.

Use babel for nyc (in yarn test:ci) or mocha (in yarn test) and transform the bootstrap script to use babel.

Use babel-transform-istanbul to instrument code.