### PR TITLE
Track initial visit on Piwik

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "lodash": "^4.17.4",
     "marked": "^0.3.6",
     "moment": "^2.14.1",
-    "piwik-react-router": "^0.6.0",
+    "piwik-react-router": "^0.9.0",
     "preact": "^8.2.1",
     "preact-compat": "^3.9.4",
     "react-addons-create-fragment": "^15.4.0",

--- a/src/index.js
+++ b/src/index.js
@@ -12,12 +12,18 @@ const store = createStore(window.__INITIAL_STATE__)
 // Piwik
 // ------------------------------------
 const { PIWIK_URL, PIWIK_SITE_ID } = process.env
-
 if (PIWIK_URL && PIWIK_SITE_ID) {
-  createPiwikConnector({
+  const piwik = createPiwikConnector({
     url: PIWIK_URL,
-    siteId: PIWIK_SITE_ID
-  }).connectToHistory(browserHistory)
+    siteId: PIWIK_SITE_ID,
+    ignoreInitialVisit: true
+  })
+
+  // Initial visit are not reported when using browserHistory.
+  // Here we’re tracking the initial page manually.
+  piwik.track(browserHistory.getCurrentLocation())
+
+  piwik.connectToHistory(browserHistory)
 }
 
 // Render Setup

--- a/yarn.lock
+++ b/yarn.lock
@@ -4721,9 +4721,9 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
-piwik-react-router@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/piwik-react-router/-/piwik-react-router-0.6.0.tgz#52e0ae771eec058f636500c2cc5089130b0e3c1d"
+piwik-react-router@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/piwik-react-router/-/piwik-react-router-0.9.0.tgz#4b7f4cbeca94ca1ec5998cfa57c650214b1f603f"
   dependencies:
     url-join "^1.1.0"
     warning "^3.0.0"


### PR DESCRIPTION
Intial visits were never tracked on Piwik.  The *new* `ignoreInitialVisit` feature on piwik-react-router cannot work with react-router’s `browserHistory` as it does not expose a `location` property.

Call `piwik.track` manually to track the initial visit/page.

**Caveats:** The document title is not set at this point, so it will not be reported in the initial track. Though this is still better than no event at all. Will be investigating `react-helmet` to fix that.