### PR TITLE
Stop comparing builds to current branch on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,6 @@ jobs:
       - restore_cache:
           name: Restore reports cache
           keys:
-            - v1-geodatagouv-reports-{{ .Branch }}-
             - v1-geodatagouv-reports-master-
 
       - run:


### PR DESCRIPTION
Comparing to the current branch doesn’t a lot of sense (unless we’re on master). It’s nicer to always have an evolving diff on a branch that always compares to the latest master build. Of course the said branch needs to always be up to date with the latest master changes.

Currently only the first commit of a branch compares to master, then all subsequent builds will compare to the previous build on that branch. If you want an overview of the changes from master, you’d need to look at all the previous builds of that branch.