### PR TITLE
Load leaflet maps only when visible on screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "react-i18next": "^4.8.0",
     "react-leaflet": "^1.5.0",
     "react-loadable": "^4.0.4",
+    "react-loadable-visibility": "^2.3.0",
     "react-paginate": "^4.1.1",
     "react-redux": "^5.0.5",
     "react-router-dom": "^4.1.2",

--- a/project.config.js
+++ b/project.config.js
@@ -70,6 +70,7 @@ module.exports = {
     'react-document-title',
     'react-i18next',
     'react-loadable',
+    'react-loadable-visibility',
     'react-paginate',
     'react-redux',
     'react-router-dom',

--- a/src/components/CenteredMap/LoadableCenteredMap.js
+++ b/src/components/CenteredMap/LoadableCenteredMap.js
@@ -1,9 +1,9 @@
 import React from 'react'
-import Loadable from 'react-loadable'
+import LoadableVisibility from 'react-loadable-visibility/react-loadable'
 
 import Loader from 'common/components/Loader'
 
-const LoadableCenteredMap = Loadable({
+const LoadableCenteredMap = LoadableVisibility({
   loader: () => import(/* webpackChunkName: 'components/map' */ './CenteredMap'),
   loading: () => <Loader loading />
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5282,6 +5282,10 @@ react-leaflet@^1.5.0:
     lodash "^4.0.0"
     warning "^3.0.0"
 
+react-loadable-visibility@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-loadable-visibility/-/react-loadable-visibility-2.3.0.tgz#2c39cc7e14f17969a130d1c4cd4bcf574d84f15e"
+
 react-loadable@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/react-loadable/-/react-loadable-4.0.4.tgz#ae96837729eeb7fd0d3bb1dc01dc0053ac147874"


### PR DESCRIPTION
Drastically reduces the loading time of the page on mobile devices.