### PR TITLE
Rename Loader’s loading to isLoading

### DIFF
--- a/src/components/CenteredMap/LoadableCenteredMap.js
+++ b/src/components/CenteredMap/LoadableCenteredMap.js
@@ -1,11 +1,10 @@
-import React from 'react'
 import LoadableVisibility from 'react-loadable-visibility/react-loadable'
 
 import Loader from 'common/components/Loader'
 
 const LoadableCenteredMap = LoadableVisibility({
   loader: () => import(/* webpackChunkName: 'components/map' */ './CenteredMap'),
-  loading: () => <Loader loading />
+  loading: Loader
 })
 
 export default LoadableCenteredMap

--- a/src/components/CenteredMap/__test__/LoadableCenteredMap.test.js
+++ b/src/components/CenteredMap/__test__/LoadableCenteredMap.test.js
@@ -8,6 +8,6 @@ describe('<LoadableCenteredMap />', () => {
   it('should be loading by default', () => {
     const wrapper = shallow(<LoadableCenteredMap vectors={{}} />)
 
-    expect(wrapper).to.containMatchingElement(<Loader isLoading />)
+    expect(wrapper).to.containMatchingElement(<Loader isLoading pastDelay={false} />)
   })
 })

--- a/src/components/CenteredMap/__test__/LoadableCenteredMap.test.js
+++ b/src/components/CenteredMap/__test__/LoadableCenteredMap.test.js
@@ -1,13 +1,13 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { shallow } from 'enzyme'
 
 import Loader from 'common/components/Loader'
 import LoadableCenteredMap from '../LoadableCenteredMap'
 
 describe('<LoadableCenteredMap />', () => {
   it('should be loading by default', () => {
-    const wrapper = mount(<LoadableCenteredMap vectors={{}} />)
+    const wrapper = shallow(<LoadableCenteredMap vectors={{}} />)
 
-    expect(wrapper).to.contain(<Loader loading />)
+    expect(wrapper).to.containMatchingElement(<Loader isLoading />)
   })
 })

--- a/src/components/Chart/LoadableChart.js
+++ b/src/components/Chart/LoadableChart.js
@@ -1,11 +1,10 @@
-import React from 'react'
 import LoadableVisibility from 'react-loadable-visibility/react-loadable'
 
 import Loader from 'common/components/Loader'
 
 const LoadableChart = LoadableVisibility({
   loader: () => import(/* webpackChunkName: 'components/chart' */ './Chart'),
-  loading: () => <Loader loading />
+  loading: Loader
 })
 
 export default LoadableChart

--- a/src/components/Chart/__test__/LoadableChart.test.js
+++ b/src/components/Chart/__test__/LoadableChart.test.js
@@ -1,13 +1,13 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { shallow } from 'enzyme'
 
 import Loader from 'common/components/Loader'
 import LoadableChart from '../LoadableChart'
 
 describe('<LoadableChart />', () => {
   it('should be loading by default', () => {
-    const wrapper = mount(<LoadableChart chartType='Line' />)
+    const wrapper = shallow(<LoadableChart chartType='Line' data={{}} />)
 
-    expect(wrapper).to.contain(<Loader loading />)
+    expect(wrapper).to.containMatchingElement(<Loader isLoading />)
   })
 })

--- a/src/components/Chart/__test__/LoadableChart.test.js
+++ b/src/components/Chart/__test__/LoadableChart.test.js
@@ -8,6 +8,6 @@ describe('<LoadableChart />', () => {
   it('should be loading by default', () => {
     const wrapper = shallow(<LoadableChart chartType='Line' data={{}} />)
 
-    expect(wrapper).to.containMatchingElement(<Loader isLoading />)
+    expect(wrapper).to.containMatchingElement(<Loader isLoading pastDelay={false} />)
   })
 })

--- a/src/components/Loader/Loader.js
+++ b/src/components/Loader/Loader.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types'
 
 import styles from './Loader.scss'
 
-const Loader = ({ loading, label = 'Chargement…', className = '', error, children }) => (
-  loading ? (
+const Loader = ({ isLoading, label, className, error, children }) => (
+  isLoading ? (
     <div className={`${styles.wrapper} ${className}`}>
       <div className={styles.loader}>
         {label}
@@ -18,7 +18,7 @@ const Loader = ({ loading, label = 'Chargement…', className = '', error, child
 )
 
 Loader.propTypes = {
-  loading: PropTypes.bool.isRequired,
+  isLoading: PropTypes.bool,
   label: PropTypes.string,
 
   className: PropTypes.string,
@@ -31,6 +31,12 @@ Loader.propTypes = {
   ]),
 
   children: PropTypes.node
+}
+
+Loader.defaultProps = {
+  isLoading: false,
+  label: 'Chargement…',
+  className: ''
 }
 
 export default Loader

--- a/src/components/Loader/Loader.js
+++ b/src/components/Loader/Loader.js
@@ -3,22 +3,47 @@ import PropTypes from 'prop-types'
 
 import styles from './Loader.scss'
 
-const Loader = ({ isLoading, label, className, error, children }) => (
-  isLoading ? (
-    <div className={`${styles.wrapper} ${className}`}>
-      <div className={styles.loader}>
-        {label}
+const Loader = ({ isLoading, pastDelay, timedOut, label, className, error, children }) => {
+  if (isLoading) {
+    if (timedOut) {
+      return (
+        <div className={styles.error}>
+          Le chargement a pris trop de temps, veuillez réessayer plus tard.
+        </div>
+      )
+    }
+
+    if (pastDelay) {
+      return (
+        <div className={`${styles.wrapper} ${className}`}>
+          <div className={styles.loader}>
+            {label}
+          </div>
+        </div>
+      )
+    }
+
+    // In case pastDelay is specified with a falsy value, let’s not display
+    // any loading as the component is ready to be displayed.
+    return null
+  }
+
+  if (error) {
+    return (
+      <div className={styles.error}>
+        Une erreur est survenue : {error.message}.
       </div>
-    </div>
-  ) : error ? (
-    <div className={styles.error}>
-      Une erreur est survenue : {error.message}.
-    </div>
-  ) : children
-)
+    )
+  }
+
+  return children
+}
 
 Loader.propTypes = {
   isLoading: PropTypes.bool,
+  pastDelay: PropTypes.bool,
+  timedOut: PropTypes.bool,
+
   label: PropTypes.string,
 
   className: PropTypes.string,
@@ -35,6 +60,9 @@ Loader.propTypes = {
 
 Loader.defaultProps = {
   isLoading: false,
+  pastDelay: true,
+  timedOut: false,
+
   label: 'Chargement…',
   className: ''
 }

--- a/src/components/Loader/__test__/Loader.test.js
+++ b/src/components/Loader/__test__/Loader.test.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
+
 import Loader from '../Loader'
 
 describe('Loader', () => {
@@ -20,6 +21,18 @@ describe('Loader', () => {
     const wrapper = shallow(<Loader isLoading={false} error={error} />)
 
     expect(wrapper).to.containMatchingElement(<div>Une erreur est survenue : Sorry….</div>)
+  })
+
+  it('should not display a loader when delay is not over', () => {
+    const wrapper = shallow(<Loader isLoading label='Hello' pastDelay={false} />)
+
+    expect(wrapper).to.be.empty
+  })
+
+  it('should display an error when the loading timed out', () => {
+    const wrapper = shallow(<Loader isLoading label='Hello' timedOut />)
+
+    expect(wrapper).to.containMatchingElement(<div>Le chargement a pris trop de temps, veuillez réessayer plus tard.</div>)
   })
 
   it('should display the underlying component when everything is ok', () => {

--- a/src/components/Loader/__test__/Loader.test.js
+++ b/src/components/Loader/__test__/Loader.test.js
@@ -3,28 +3,28 @@ import { shallow } from 'enzyme'
 import Loader from '../Loader'
 
 describe('Loader', () => {
-  it('should display a loader when loading is true', () => {
-    const wrapper = shallow(<Loader loading />)
+  it('should display a loader when isLoading is true', () => {
+    const wrapper = shallow(<Loader isLoading />)
 
     expect(wrapper).to.containMatchingElement(<div><div>Chargement…</div></div>)
   })
 
   it('should change the label when defined', () => {
-    const wrapper = shallow(<Loader loading label='Hello' />)
+    const wrapper = shallow(<Loader isLoading label='Hello' />)
 
     expect(wrapper).to.containMatchingElement(<div>Hello</div>)
   })
 
-  it('should display an error when not loading and errored', () => {
+  it('should display an error when not isLoading and errored', () => {
     const error = new Error('Sorry…')
-    const wrapper = shallow(<Loader loading={false} error={error} />)
+    const wrapper = shallow(<Loader isLoading={false} error={error} />)
 
     expect(wrapper).to.containMatchingElement(<div>Une erreur est survenue : Sorry….</div>)
   })
 
   it('should display the underlying component when everything is ok', () => {
     const child = <div>Finally!</div>
-    const wrapper = shallow(<Loader loading={false}>{child}</Loader>)
+    const wrapper = shallow(<Loader isLoading={false}>{child}</Loader>)
 
     expect(wrapper).to.contain(child)
   })

--- a/src/helpers/withResolver.js
+++ b/src/helpers/withResolver.js
@@ -33,7 +33,7 @@ export default function withResolver(WrappedComponent, dependencies) {
       }
 
       if (!dependenciesReady) {
-        return <Loader loading />
+        return <Loader isLoading />
       }
 
       return <WrappedComponent {...this.state} {...this.props} />

--- a/src/modules/Publication/components/AddCatalogs/AddCatalogs.js
+++ b/src/modules/Publication/components/AddCatalogs/AddCatalogs.js
@@ -29,7 +29,7 @@ class AddCatalogs extends Component {
   render() {
     const { catalogs } = this.state
     const { sourceCatalogs, addCatalog } = this.props
-    if (!this.state.catalogs) return <Loader loading className={loader} />
+    if (!this.state.catalogs) return <Loader isLoading className={loader} />
 
     const candidateCatalogs = getCandidateCatalogs(catalogs, sourceCatalogs)
     const sortedCatalogs = getCatalogOrderByScore(candidateCatalogs)

--- a/src/routes/Catalogs/routes/Catalog/components/CatalogHarvestsView/CatalogHarvestsView.js
+++ b/src/routes/Catalogs/routes/Catalog/components/CatalogHarvestsView/CatalogHarvestsView.js
@@ -64,7 +64,7 @@ class CatalogHarvestsView extends React.PureComponent {
       <div>
         <h2>{t('CatalogHarvestsView.title')}</h2>
 
-        <Loader loading={harvests.pending} error={harvests.error}>
+        <Loader isLoading={harvests.pending} error={harvests.error}>
           <div className={styles.container}>
             <div className={styles.table}>
               <CatalogHarvestsTable

--- a/src/routes/Catalogs/routes/Catalog/components/CatalogPage/CatalogPage.js
+++ b/src/routes/Catalogs/routes/Catalog/components/CatalogPage/CatalogPage.js
@@ -72,7 +72,7 @@ class CatalogPage extends React.PureComponent {
 
     return (
       <div className={styles.container}>
-        <Loader loading={catalog.pending || metrics.pending} error={catalog.error || metrics.error}>
+        <Loader isLoading={catalog.pending || metrics.pending} error={catalog.error || metrics.error}>
           <CatalogView
             catalog={catalog.catalog}
             metrics={metrics.metrics}

--- a/src/routes/Catalogs/routes/CatalogHarvest/components/CatalogHarvestPage/CatalogHarvestPage.js
+++ b/src/routes/Catalogs/routes/CatalogHarvest/components/CatalogHarvestPage/CatalogHarvestPage.js
@@ -54,7 +54,7 @@ class CatalogHarvestPage extends React.PureComponent {
 
     return (
       <div className={styles.container}>
-        <Loader loading={catalog.pending || harvest.pending} error={catalog.error || harvest.error}>
+        <Loader isLoading={catalog.pending || harvest.pending} error={catalog.error || harvest.error}>
           <CatalogHarvestView
             catalog={catalog.catalog}
             harvest={harvest.harvest}

--- a/src/routes/Catalogs/routes/CatalogsList/components/CatalogsListPage/CatalogsListPage.js
+++ b/src/routes/Catalogs/routes/CatalogsList/components/CatalogsListPage/CatalogsListPage.js
@@ -39,7 +39,7 @@ class CatalogsListPage extends React.PureComponent {
     return (
       <DocumentTitle title={t('CatalogsListPage.documentTitle')}>
         <div className={styles.container}>
-          <Loader loading={catalogs.pending} error={catalogs.error}>
+          <Loader isLoading={catalogs.pending} error={catalogs.error}>
             <div>
               {catalogs.catalogs.map(catalog => (
                 <div key={catalog._id} className={styles.catalog} >

--- a/src/routes/Dataset/components/DatasetPage/DatasetPage.js
+++ b/src/routes/Dataset/components/DatasetPage/DatasetPage.js
@@ -54,7 +54,7 @@ class DatasetPage extends React.PureComponent {
     return (
       <div>
         <Loader
-          loading={dataset.pending || !dataset.dataset || publication.pending}
+          isLoading={dataset.pending || !dataset.dataset || publication.pending}
           error={dataset.error}
           className={styles.loader}
         >

--- a/src/routes/Dataset/components/DatasetPreview/DatasetPreview.js
+++ b/src/routes/Dataset/components/DatasetPreview/DatasetPreview.js
@@ -62,7 +62,7 @@ class DatasetPreview extends React.PureComponent {
           <button className={styles.closeButton} onClick={closePreview}>X</button>
         </div>
 
-        <Loader loading={geoJson.pending} error={geoJson.error} className={styles.loader}>
+        <Loader isLoading={geoJson.pending} error={geoJson.error} className={styles.loader}>
           <div className={styles.wrapper}>
             {mode === 'map' ? (
               <CenteredMap

--- a/src/routes/Dataset/components/DatasetView/DatasetView.js
+++ b/src/routes/Dataset/components/DatasetView/DatasetView.js
@@ -123,7 +123,7 @@ class DatasetView extends React.PureComponent {
               <div className={styles.aside}>
                 {publication && publication.remoteId && (
                   <DatasetBlock title={t('components.DatasetView.section.producer')}>
-                    <Loader loading={dataGouvDataset.pending}>
+                    <Loader isLoading={dataGouvDataset.pending}>
                       {dataGouvDataset.dataset && (
                         <DatasetProducer organization={dataGouvDataset.dataset.organization} />
                       )}

--- a/src/routes/Search/components/SearchPage/SearchPage.js
+++ b/src/routes/Search/components/SearchPage/SearchPage.js
@@ -129,7 +129,7 @@ class SearchPage extends React.PureComponent {
             />
           </div>
 
-          <Loader loading={search.pending} error={search.error}>
+          <Loader isLoading={search.pending} error={search.error}>
             <SearchResults
               page={search.parsedQuery.page}
               query={search.search.query}


### PR DESCRIPTION
This allows to be compatible with react-loader, without having to create unnecessary components and renders.

Also, `isLoading` as a bool sounds better than `loading`.