### PR TITLE
Remove component children from <options />

### DIFF
--- a/src/components/LanguageSelection/LanguageSelection.js
+++ b/src/components/LanguageSelection/LanguageSelection.js
@@ -28,8 +28,8 @@ class LanguageSelection extends React.PureComponent {
       <div>
         {t('components.LanguageSelection.languageSelection')} :
         <select className={styles.select} value={language} onChange={this.changeLanguage}>
-          <option value='en'>English <span className={styles.emoji} role='img' aria-label='uk-flag'>🇬🇧</span></option>
-          <option value='fr'>Français <span className={styles.emoji} role='img' aria-label='fr-flag'>🇫🇷</span></option>
+          <option value='en'>English 🇬🇧</option>
+          <option value='fr'>Français 🇫🇷</option>
         </select>
       </div>
     )

--- a/src/components/LanguageSelection/LanguageSelection.scss
+++ b/src/components/LanguageSelection/LanguageSelection.scss
@@ -3,7 +3,3 @@
   width: 100px;
   height: 30px;
 }
-
-.emoji {
-  margin-left: 1em;
-}


### PR DESCRIPTION
Only text is allowed.

React warns about that and actually removes the markup, while preact strips the component to include the inner text.