### PR TITLE
Update html lang attribute with helmet

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Helmet } from 'react-helmet'
 import PropTypes from 'prop-types'
 
 import { BrowserRouter, Switch, Route } from 'react-router-dom'
@@ -37,7 +36,6 @@ class App extends React.Component {
         <I18nextProvider i18n={i18n}>
           <BrowserRouter>
             <PageLayout>
-              <Helmet titleTemplate='%s | inspire.data.gouv.fr' defaultTitle='inspire.data.gouv.fr' />
               <ScrollToTop />
               <TrackPageViews />
 

--- a/src/components/PageLayout/PageLayout.js
+++ b/src/components/PageLayout/PageLayout.js
@@ -1,4 +1,6 @@
 import React from 'react'
+import { Helmet } from 'react-helmet'
+import { translate } from 'react-i18next'
 import { StickyContainer } from 'react-sticky'
 import PropTypes from 'prop-types'
 
@@ -7,8 +9,13 @@ import Footer from '../../components/Footer'
 
 import styles from './PageLayout.scss'
 
-export const PageLayout = ({ children }) => (
+export const PageLayout = ({ children, i18n }) => (
   <StickyContainer className={styles.content}>
+    <Helmet
+      titleTemplate='%s | inspire.data.gouv.fr'
+      defaultTitle='inspire.data.gouv.fr'
+      htmlAttributes={{ lang: i18n.language }}
+    />
     <Header />
     <div className={styles.body}>
       {children}
@@ -19,6 +26,9 @@ export const PageLayout = ({ children }) => (
 
 PageLayout.propTypes = {
   children: PropTypes.node,
+  i18n: PropTypes.shape({
+    language: PropTypes.string.isRequired
+  }).isRequired
 }
 
-export default PageLayout
+export default translate()(PageLayout)

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="fr">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Move Helmet defaults to PageLayout so we can use react-i18next’s translate HOC.
Default the language in index.html to fr sice we don’t have SSR yet.