### PR TITLE
Meilleur vérification des traductions 

### DIFF
--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -4,11 +4,9 @@ import PropTypes from 'prop-types'
 
 import styles from './Filter.scss'
 
-const Filter = ({ detail, remove, filter, style, onClick, t, i18n }) => {
-  const title = t(`components.Filter.types.${filter.name}`)
-  const value = i18n.exists(`components.Filter.values.${filter.value}`)
-    ? t(`components.Filter.values.${filter.value}`)
-    : filter.value
+const Filter = ({ detail, remove, filter, style, onClick, t }) => {
+  const title = t(`components.Filter.${filter.name}`)
+  const value = t([`components.Filter.${filter.value}`, filter.value])
 
   return (
     <button
@@ -47,7 +45,6 @@ Filter.propTypes = {
   onClick: PropTypes.func,
 
   t: PropTypes.func.isRequired,
-  i18n: PropTypes.object.isRequired
 }
 
 Filter.defaultProps = {

--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -6,7 +6,9 @@ import styles from './Filter.scss'
 
 const Filter = ({ detail, remove, filter, style, onClick, t }) => {
   const title = t(`components.Filter.${filter.name}`)
-  const value = t([`components.Filter.${filter.value}`, filter.value])
+  const value = t(`components.Filter.${filter.value}`, {
+    defaultValue: filter.value
+  })
 
   return (
     <button
@@ -44,7 +46,7 @@ Filter.propTypes = {
   style: PropTypes.object,
   onClick: PropTypes.func,
 
-  t: PropTypes.func.isRequired,
+  t: PropTypes.func.isRequired
 }
 
 Filter.defaultProps = {

--- a/src/routes/Catalogs/routes/Catalog/components/CatalogCharts/DoughnutChart/DoughnutChart.js
+++ b/src/routes/Catalogs/routes/Catalog/components/CatalogCharts/DoughnutChart/DoughnutChart.js
@@ -14,7 +14,7 @@ export const formatData = (data, t) => {
   const labels = Object.keys(data).sort((a, b) => data[a] < data[b])
 
   return {
-    labels: labels.map(label => t(`components.DoughnutChart.${label}`)),
+    labels: labels.map(label => t([`components.DoughnutChart.${label}`, label])),
     datasets: [
       {
         data: labels.map(label => data[label]),

--- a/src/routes/Catalogs/routes/Catalog/components/CatalogCharts/DoughnutChart/DoughnutChart.js
+++ b/src/routes/Catalogs/routes/Catalog/components/CatalogCharts/DoughnutChart/DoughnutChart.js
@@ -14,7 +14,9 @@ export const formatData = (data, t) => {
   const labels = Object.keys(data).sort((a, b) => data[a] < data[b])
 
   return {
-    labels: labels.map(label => t([`components.DoughnutChart.${label}`, label])),
+    labels: labels.map(label => t(`components.DoughnutChart.${label}`, {
+      defaultValue: label
+    })),
     datasets: [
       {
         data: labels.map(label => data[label]),

--- a/src/routes/Dataset/components/DatasetHeader/DatasetHeader.js
+++ b/src/routes/Dataset/components/DatasetHeader/DatasetHeader.js
@@ -9,14 +9,12 @@ import { getLicense } from 'common/helpers/dataGouvChecks'
 
 import styles from './DatasetHeader.scss'
 
-const DatasetHeader = ({ dataset, t, i18n }) => {
+const DatasetHeader = ({ dataset, t }) => {
   const { title, description, type, purpose, lineage, inspireTheme } = dataset.metadata
 
   const revisionDate = doneSince(dataset.revisionDate)
   const license = getLicense(dataset.metadata.license)
-  const dataType = i18n.exists(`Common:enums.dataTypes.${type}`)
-    ? t(`Common:enums.dataTypes.${type}`)
-    : type
+  const dataType = t([`Common:enums.dataTypes.${type}`, type])
 
   return (
     <div className={styles.container}>
@@ -85,8 +83,7 @@ DatasetHeader.propTypes = {
     }).isRequired
   }).isRequired,
 
-  t: PropTypes.func.isRequired,
-  i18n: PropTypes.object.isRequired
+  t: PropTypes.func.isRequired
 }
 
 export default translate('Dataset')(DatasetHeader)

--- a/src/routes/Dataset/components/DatasetHeader/DatasetHeader.js
+++ b/src/routes/Dataset/components/DatasetHeader/DatasetHeader.js
@@ -14,7 +14,9 @@ const DatasetHeader = ({ dataset, t }) => {
 
   const revisionDate = doneSince(dataset.revisionDate)
   const license = getLicense(dataset.metadata.license)
-  const dataType = t([`Common:enums.dataTypes.${type}`, type])
+  const dataType = t(`Common:enums.dataTypes.${type}`, {
+    defaultValue: type
+  })
 
   return (
     <div className={styles.container}>

--- a/src/routes/Dataset/components/DatasetTechnicalInfo/DatasetTechnicalInfo.js
+++ b/src/routes/Dataset/components/DatasetTechnicalInfo/DatasetTechnicalInfo.js
@@ -26,7 +26,9 @@ const DatasetTechnicalInfo = ({ dataset, status, t, i18n }) => {
   const createDate = creationDate
     ? moment(creationDate).format('DD/MM/YYYY')
     : t('Common:enums.unknownData.unknown', { context: 'female' })
-  const dataType = t([`Common:enums.dataTypes.${type}`, type])
+  const dataType = t(`Common:enums.dataTypes.${type}`, {
+    defaultValue: type
+  })
   const topicCat = t([`Common:enums.topicCategories.${topicCategory}`, 'Common:enums.unknownData.notSpecified'], { context: 'female' })
 
   return (

--- a/src/routes/Dataset/components/DatasetTechnicalInfo/DatasetTechnicalInfo.js
+++ b/src/routes/Dataset/components/DatasetTechnicalInfo/DatasetTechnicalInfo.js
@@ -26,12 +26,8 @@ const DatasetTechnicalInfo = ({ dataset, status, t, i18n }) => {
   const createDate = creationDate
     ? moment(creationDate).format('DD/MM/YYYY')
     : t('Common:enums.unknownData.unknown', { context: 'female' })
-  const dataType = i18n.exists(`Common:enums.dataTypes.${type}`)
-    ? t(`Common:enums.dataTypes.${type}`)
-    : type
-  const topicCat = i18n.exists(`Common:enums.topicCategories.${topicCategory}`)
-    ? t(`Common:enums.topicCategories.${topicCategory}`)
-    : t('Common:enums.unknownData.notSpecified', { context: 'female' })
+  const dataType = t([`Common:enums.dataTypes.${type}`, type])
+  const topicCat = t([`Common:enums.topicCategories.${topicCategory}`, 'Common:enums.unknownData.notSpecified'], { context: 'female' })
 
   return (
     <div className={styles.container}>


### PR DESCRIPTION
Nous n'avons plus besoin d'utiliser `i18n.exists` pour vérifier qu'une traduction existe bien.

Merci @tusbar -> https://github.com/i18next/i18next-gitbook/pull/15