### PR TITLE
Force default locale to french & update {react-,}i18n

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "dependencies": {
     "chart.js": "^2.5.0",
     "hoist-non-react-statics": "^2.3.0",
-    "i18next": "^8.4.3",
+    "i18next": "^9.0.0",
     "i18next-browser-languagedetector": "^2.0.0",
     "leaflet": "^1.2.0",
     "lodash-es": "^4.17.4",
@@ -104,7 +104,7 @@
     "react-addons-create-fragment": "^15.4.0",
     "react-chartjs-2": "^2.6.1",
     "react-helmet": "^5.1.3",
-    "react-i18next": "^4.8.0",
+    "react-i18next": "^5.2.0",
     "react-leaflet": "^1.6.3",
     "react-loadable": "^4.0.4",
     "react-loadable-visibility": "^2.3.0",

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -2,31 +2,27 @@ import i18next from 'i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 import moment from 'moment'
 
+import { injectLocale } from './helpers'
+
+const defaultNamespace = 'Common'
 const availableLanguages = [
-  'en',
-  'fr'
+  'fr',
+  'en'
 ]
 
 export default () => {
   const i18n = i18next
     .use(LanguageDetector)
     .init({
-      resources: {
-        en: {
-          Common: require('../locales/en.json')
-        },
-        fr: {
-          Common: require('../locales/fr.json')
-        }
-      },
-
       whitelist: [
         ...availableLanguages
       ],
 
-      fallbackLng: 'en',
+      load: 'languageOnly',
+      lng: 'fr',
+      fallbackLng: 'fr',
 
-      defaultNS: 'Common',
+      defaultNS: defaultNamespace,
 
       interpolation: {
         formatSeparator: ','
@@ -36,6 +32,14 @@ export default () => {
         wait: true
       }
     })
+
+  availableLanguages.forEach(locale => {
+    injectLocale(i18n, {
+      locale,
+      namespace: defaultNamespace,
+      resources: require(`../locales/${locale}.json`)
+    })
+  })
 
   i18n.availableLanguages = availableLanguages
   moment.locale(i18n.language)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3663,9 +3663,9 @@ i18next-browser-languagedetector@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-2.0.0.tgz#4d9df2bd1a5deda3c8c0a6d3db62d50388b9eedd"
 
-i18next@^8.4.3:
-  version "8.4.3"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-8.4.3.tgz#36b6ff516c4f992010eedcce24a36c4609e8c7dc"
+i18next@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-9.0.0.tgz#a89ab0481b5b6b3964f55b12f03de9063d8f4500"
 
 iconv-lite@0.4.13:
   version "0.4.13"
@@ -6026,9 +6026,9 @@ react-helmet@^5.1.3:
     prop-types "^15.5.4"
     react-side-effect "^1.1.0"
 
-react-i18next@^4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-4.8.0.tgz#92f0d281c5f39ac8f3c3f381562d523e9d830254"
+react-i18next@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-5.2.0.tgz#cfedc349b36860e261077cca7af4794907b0a12f"
   dependencies:
     hoist-non-react-statics "1.2.0"
 


### PR DESCRIPTION
Some strings are not translated to english yet (hardcoded in french), we’re allowing the option to switch to english at the bottom of the page, but defaulting to french.

`i18next` has been stripped of old code so everything is lighter.

We’re now waiting on https://github.com/i18next/react-i18next/pull/291 for lighter es builds.

EDIT: merged.