### PR TITLE
Add global style loader to stop delivering CSS from CDNs

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -125,8 +125,25 @@ config.module.rules.push({
   ]
 })
 
-// Global Styles
+// Styles
 // ------------------------------------
+const cssMinimizeOptions = {
+  autoprefixer: {
+    add: true,
+    remove: true,
+    browsers: ['last 2 versions']
+  },
+  discardComments: {
+    removeAll: true
+  },
+  discardUnused: false,
+  mergeIdents: false,
+  reduceIdents: false,
+  safe: true,
+  sourcemap: project.sourcemaps
+}
+
+// Global styles
 const globalStyles = new ExtractTextPlugin({
   filename: 'styles/global.[contenthash].css',
   allChunks: true,
@@ -145,21 +162,7 @@ config.module.rules.push({
         loader: 'css-loader',
         options: {
           sourceMap: project.sourcemaps,
-          minimize: {
-            autoprefixer: {
-              add: true,
-              remove: true,
-              browsers: ['last 2 versions']
-            },
-            discardComments: {
-              removeAll: true
-            },
-            discardUnused: false,
-            mergeIdents: false,
-            reduceIdents: false,
-            safe: true,
-            sourcemap: project.sourcemaps
-          }
+          minimize: cssMinimizeOptions
         }
       },
       {
@@ -178,7 +181,6 @@ config.module.rules.push({
 config.plugins.push(globalStyles)
 
 // Local Styles
-// ------------------------------------
 const localStyles = new ExtractTextPlugin({
   filename: 'styles/[name].[contenthash].css',
   allChunks: true,
@@ -201,21 +203,7 @@ config.module.rules.push({
           localIdentName: '[name]-[hash:base64:8]',
           camelCase: 'only',
           sourceMap: project.sourcemaps,
-          minimize: {
-            autoprefixer: {
-              add: true,
-              remove: true,
-              browsers: ['last 2 versions']
-            },
-            discardComments: {
-              removeAll: true
-            },
-            discardUnused: false,
-            mergeIdents: false,
-            reduceIdents: false,
-            safe: true,
-            sourcemap: project.sourcemaps
-          }
+          minimize: cssMinimizeOptions
         }
       },
       {
@@ -234,7 +222,6 @@ config.module.rules.push({
 config.plugins.push(localStyles)
 
 // Vendor Styles
-// ------------------------------------
 config.module.rules.push({
   test: /\.css$/,
   include: [
@@ -251,21 +238,7 @@ config.module.rules.push({
       loader: 'css-loader',
       options: {
         sourceMap: __DEV__,
-        minimize: {
-          autoprefixer: {
-            add: true,
-            remove: true,
-            browsers: ['last 2 versions']
-          },
-          discardComments: {
-            removeAll: true
-          },
-          discardUnused: false,
-          mergeIdents: false,
-          reduceIdents: false,
-          safe: true,
-          sourcemap: __DEV__
-        }
+        minimize: cssMinimizeOptions
       }
     }
   ]

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -125,6 +125,58 @@ config.module.rules.push({
   ]
 })
 
+// Global Styles
+// ------------------------------------
+const globalStyles = new ExtractTextPlugin({
+  filename: 'styles/global.[contenthash].css',
+  allChunks: true,
+  disable: !__PROD__
+})
+
+config.module.rules.push({
+  test: /\.(sass|scss)$/,
+  include: [
+    inProjectSrc('styles')
+  ],
+  loader: globalStyles.extract({
+    fallback: 'style-loader',
+    use: [
+      {
+        loader: 'css-loader',
+        options: {
+          sourceMap: project.sourcemaps,
+          minimize: {
+            autoprefixer: {
+              add: true,
+              remove: true,
+              browsers: ['last 2 versions']
+            },
+            discardComments: {
+              removeAll: true
+            },
+            discardUnused: false,
+            mergeIdents: false,
+            reduceIdents: false,
+            safe: true,
+            sourcemap: project.sourcemaps
+          }
+        }
+      },
+      {
+        loader: 'sass-loader',
+        options: {
+          sourceMap: project.sourcemaps,
+          includePaths: [
+            inProjectSrc('styles')
+          ]
+        }
+      }
+    ]
+  })
+})
+
+config.plugins.push(globalStyles)
+
 // Local Styles
 // ------------------------------------
 const localStyles = new ExtractTextPlugin({
@@ -136,7 +188,8 @@ const localStyles = new ExtractTextPlugin({
 config.module.rules.push({
   test: /\.(sass|scss)$/,
   exclude: [
-    inProject('node_modules')
+    inProject('node_module'),
+    inProjectSrc('styles')
   ],
   loader: localStyles.extract({
     fallback: 'style-loader',

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -313,8 +313,8 @@ config.module.rules.push({
     test: new RegExp(`\\.${extension}$`),
     loader: 'url-loader',
     options: {
-      name: 'fonts/[name].[ext]',
-      limit: 10000,
+      name: __DEV__ ? 'fonts/[name].[ext]' : 'fonts/[name].[hash].[ext]',
+      limit: 8192,
       mimetype
     }
   })

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "reactable": "^0.14.1",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
+    "semantic-ui-css": "2.2.10",
     "underscore.string": "^3.3.4"
   },
   "engines": {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -18,6 +18,8 @@ import PublicationRoute from '../routes/Publication'
 
 import NotFoundRoute from '../routes/NotFound'
 
+import '../styles/global.scss'
+
 class App extends React.Component {
   static propTypes = {
     store: PropTypes.object.isRequired,

--- a/src/index.html
+++ b/src/index.html
@@ -26,11 +26,6 @@
     <link rel="icon" type="image/png" href="/favicons/favicon-16x16.png" sizes="16x16">
     <link rel="manifest" href="/favicons/manifest.json">
     <link rel="mask-icon" href="/favicons/safari-pinned-tab.svg" color="#5bbad5">
-
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.10/components/reset.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.10/components/site.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.10/components/label.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.10/components/icon.min.css">
   </head>
   <body>
     <!--[if lt IE 10]>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,0 +1,4 @@
+@import '~semantic-ui-css/components/reset.css';
+@import '~semantic-ui-css/components/site.css';
+@import '~semantic-ui-css/components/label.css';
+@import '~semantic-ui-css/components/icon.css';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4197,6 +4197,10 @@ istanbul-reports@^1.1.1:
   dependencies:
     handlebars "^4.0.3"
 
+jquery@x.*:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
+
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
@@ -6525,6 +6529,12 @@ seek-bzip@^1.0.3:
   resolved "https://registry.yarnpkg.com/seek-bzip/-/seek-bzip-1.0.5.tgz#cfe917cb3d274bcffac792758af53173eb1fabdc"
   dependencies:
     commander "~2.8.1"
+
+semantic-ui-css@2.2.10:
+  version "2.2.10"
+  resolved "https://registry.yarnpkg.com/semantic-ui-css/-/semantic-ui-css-2.2.10.tgz#f8f4470dbeffca0f0f3ff4fb71a35c71e88ad89c"
+  dependencies:
+    jquery x.*
 
 semver-regex@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Basically this adds semantic-ui (specific version so we don’t break the interface looks) to reproduce exactly the same behavior as having the CSS linked from the CDN.

This also embeds the fonts (I changed the font configuration in webpack a little, nothing crazy).

Don’t be too scared by the bundle output changes (I know 375KB is a lot – but most of it is not served, only one version of the `icon` font will be served at a time) and the CSS is actually lighter when all merged in the same file (and one local request is better than 4 on a CDN).

---

```
File sizes after gzip:

  dist/fonts/icons.eot                      95.9 KB
  dist/fonts/icons.ttf                      95.81 KB
  dist/fonts/icons.woff                     95.64 KB
  dist/scripts/vendor.js                    75.96 KB (+ 3 B)
  dist/fonts/icons.woff2                    75.36 KB
  dist/scripts/modules/components/map.js    59.83 KB (- 2 B)
  dist/scripts/modules/components/chart.js  45.14 KB (+ 3 B)
  dist/scripts/app.js                       18.99 KB (+ 11 B)
  dist/styles/global.css                    12.25 KB
  dist/scripts/modules/dataset.js           11.91 KB (- 1 B)
  dist/scripts/modules/publication.js       7.59 KB (+ 4 B)
  dist/styles/app.css                       6.87 KB
  dist/scripts/modules/catalogs.js          6.39 KB
  dist/scripts/modules/search.js            4.85 KB (- 2 B)
  dist/scripts/modules/common.js            2.41 KB (+ 1 B)
  dist/index.html                           1.21 KB (- 41 B)
  dist/scripts/modules/events.js            1.15 KB (- 1 B)
  dist/scripts/manifest.js                  1.04 KB (- 2 B)

  TOTAL                                     618.31 KB (+ 374.93 KB)
```

---

Close #413 