### PR TITLE
Remove unused label style from semantic-ui

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,4 +1,3 @@
 @import '~semantic-ui-css/components/reset.css';
 @import '~semantic-ui-css/components/site.css';
-@import '~semantic-ui-css/components/label.css';
 @import '~semantic-ui-css/components/icon.css';


### PR DESCRIPTION
I really believe that this is not used at all.