### PR TITLE
Disable ci build when deploying/pushing to gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,6 @@ defaults:
   filters: &default_filters
     tags:
       only: '/v[0-9]+(\.[0-9]+)*/'
-    branches:
-      ignore: gh-pages
 
   attach_workspace: &attach_workspace
     attach_workspace:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "cross-env NODE_ENV=test mocha -r babel-register -r build/tests/bootstrap.js src/**/*.test.js",
     "test:ci": "cross-env NODE_ENV=test MOCHA_FILE=reports/tests/geodatagouv/results.xml nyc mocha -r build/tests/bootstrap.js --reporter mocha-circleci-reporter src/**/*.test.js",
     "codecov": "codecov",
-    "deploy": "gh-pages -d dist",
+    "deploy": "gh-pages -d dist -m 'Deploy [skip ci]'",
     "lint": "npm run lint:scripts && npm run lint:styles",
     "lint:scripts": "eslint .",
     "lint:styles": "stylelint **/*.scss",


### PR DESCRIPTION
So we don’t have a useless circle.yml just for the gh-pages branch.