### PR TITLE
Get rid of unmaintained react-sticky

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "react-paginate": "^4.1.1",
     "react-redux": "^5.0.6",
     "react-router-dom": "^4.2.2",
-    "react-sticky": "^5.0.5",
     "reactable": "^0.14.1",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",

--- a/project.config.js
+++ b/project.config.js
@@ -74,7 +74,6 @@ module.exports = {
     'react-paginate',
     'react-redux',
     'react-router-dom',
-    'react-sticky',
     'reactable',
     'redux',
     'redux-thunk'

--- a/src/components/PageLayout/PageLayout.js
+++ b/src/components/PageLayout/PageLayout.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Helmet } from 'react-helmet'
 import { translate } from 'react-i18next'
-import { StickyContainer } from 'react-sticky'
 import PropTypes from 'prop-types'
 
 import Header from '../../components/Header'
@@ -10,7 +9,7 @@ import Footer from '../../components/Footer'
 import styles from './PageLayout.scss'
 
 export const PageLayout = ({ children, i18n }) => (
-  <StickyContainer className={styles.content}>
+  <div className={styles.content}>
     <Helmet
       titleTemplate='%s | inspire.data.gouv.fr'
       defaultTitle='inspire.data.gouv.fr'
@@ -21,7 +20,7 @@ export const PageLayout = ({ children, i18n }) => (
       {children}
     </div>
     <Footer />
-  </StickyContainer>
+  </div>
 )
 
 PageLayout.propTypes = {

--- a/src/components/Warning/Warning.js
+++ b/src/components/Warning/Warning.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Sticky } from 'react-sticky'
 
 import styles from './Warning.scss'
 
@@ -34,7 +33,7 @@ class Warning extends React.PureComponent {
     const color = error ? styles.errorStyle : styles.warning
 
     return (
-      <Sticky className={`${styles.sticky} ${color}`}>
+      <div className={`${styles.container} ${color}`}>
         <div className={styles.content}>
           <div className={styles.bold}>{title}</div>
           {children}
@@ -42,7 +41,7 @@ class Warning extends React.PureComponent {
         <div className={styles.closeIcon} onClick={this.closeWarning}>
           <i className='big remove icon' />
         </div>
-      </Sticky>
+      </div>
     )
   }
 }

--- a/src/components/Warning/Warning.scss
+++ b/src/components/Warning/Warning.scss
@@ -1,7 +1,6 @@
 @import 'variables';
 
-.sticky {
-  z-index: 600;
+.container {
   display: flex;
   justify-content: center;
   align-items: center;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6110,12 +6110,6 @@ react-side-effect@^1.1.0:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
 
-react-sticky@^5.0.5:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/react-sticky/-/react-sticky-5.0.8.tgz#d5f85f96977f410081d792ab81886c622c5d8b14"
-  dependencies:
-    prop-types "^15.5.8"
-
 react-test-renderer@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.6.1.tgz#026f4a5bb5552661fd2cc4bbcd0d4bc8a35ebf7e"


### PR DESCRIPTION
The warning does not need to be always in the viewport, it is already big enough.

---

```
File sizes after gzip:

  dist/fonts/icons.eot                      95.9 KB
  dist/fonts/icons.ttf                      95.81 KB
  dist/fonts/icons.woff                     95.64 KB
  dist/fonts/icons.woff2                    75.36 KB
  dist/scripts/vendor.js                    74.52 KB (- 1.45 KB)
  dist/scripts/modules/components/map.js    59.82 KB (- 9 B)
  dist/scripts/modules/components/chart.js  45.13 KB (- 4 B)
  dist/scripts/app.js                       19.03 KB (- 17 B)
  dist/scripts/modules/dataset.js           11.88 KB (- 27 B)
  dist/styles/global.css                    9.44 KB
  dist/scripts/modules/publication.js       7.58 KB (- 3 B)
  dist/styles/app.css                       6.86 KB (- 11 B)
  dist/scripts/modules/catalogs.js          6.42 KB (+ 9 B)
  dist/scripts/modules/search.js            4.85 KB
  dist/scripts/modules/common.js            2.41 KB (- 5 B)
  dist/index.html                           1.21 KB (- 4 B)
  dist/scripts/modules/events.js            1.15 KB (- 2 B)
  dist/scripts/manifest.js                  1.05 KB (- 1 B)

  TOTAL                                     614.07 KB (- 1.53 KB)
```