### PR TITLE
Allow clearing the search query

### DIFF
--- a/src/routes/Search/modules/__test__/query.test.js
+++ b/src/routes/Search/modules/__test__/query.test.js
@@ -1,0 +1,29 @@
+import { update } from '../query'
+
+describe('Search.modules.query', () => {
+  describe('update', () => {
+    it('should set q when specifying it', () => {
+      const newQuery = update('', { q: 'foo' })
+
+      expect(newQuery.q).to.equal('foo')
+    })
+
+    it('should unset q when specifying an empty q', () => {
+      const newQuery = update('?q=foo', { q: '' })
+
+      expect(newQuery.q).to.be.undefined
+    })
+
+    it('should not change q, when not specifying it', () => {
+      const newQuery = update('?q=foo', {})
+
+      expect(newQuery.q).to.equal('foo')
+    })
+
+    it('should update q when specifying a new one', () => {
+      const newQuery = update('?q=foo', { q: 'bar' })
+
+      expect(newQuery.q).to.equal('bar')
+    })
+  })
+})

--- a/src/routes/Search/modules/query.js
+++ b/src/routes/Search/modules/query.js
@@ -55,7 +55,7 @@ export const update = (search = '', changes) => {
     ...filters
   } = parseQueryString(search)
 
-  const q = changes.q || iq
+  const q = 'q' in changes ? changes.q : iq
 
   // Either we specify a page number, or we go back to the first page.
   const page = changes.page || 1


### PR DESCRIPTION
When clearing `q`, it kept its previous value.