### PR TITLE
Remove resolve.modules from webpack and fix broken import

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -35,10 +35,6 @@ const config = {
   },
 
   resolve: {
-    modules: [
-      inProject(project.srcDir),
-      inProject('node_modules')
-    ],
     extensions: [
       '.js',
       '.jsx',

--- a/src/routes/Search/components/FiltersSummary/FiltersSummary.js
+++ b/src/routes/Search/components/FiltersSummary/FiltersSummary.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { translate } from 'react-i18next'
 import PropTypes from 'prop-types'
 
-import Filter from 'components/Filter'
+import Filter from 'common/components/Filter'
 
 import styles from './FiltersSummary.scss'
 


### PR DESCRIPTION
We should not be aliasing `src` as one of the module roots (thus allowing to import anything from `src` without using relative paths). Also, node_modules is already in there by default.