### PR TITLE
Introduce fluid containers and make catalogs list page fluid

### DIFF
--- a/src/components/Container/Container.js
+++ b/src/components/Container/Container.js
@@ -3,15 +3,21 @@ import PropTypes from 'prop-types'
 
 import styles from './Container.scss'
 
-const Container = ({ children, style }) => (
-  <div className={styles.container} style={style}>
+const Container = ({ children, fluid }) => (
+  <div className={styles.container} style={{
+    maxWidth: fluid ? null : 1200
+  }}>
     {children}
   </div>
 )
 
 Container.propTypes = {
   children: PropTypes.node,
-  style: PropTypes.object
+  fluid: PropTypes.bool
+}
+
+Container.defaultProps = {
+  fluid: false
 }
 
 export default Container

--- a/src/components/Container/Container.scss
+++ b/src/components/Container/Container.scss
@@ -1,7 +1,6 @@
 .container {
   position: relative;
   width: 100%;
-  max-width: 1200px;
   margin: 0 auto;
   padding: 0 20px;
 

--- a/src/routes/Catalogs/routes/CatalogsList/components/CatalogsListPage/CatalogsListPage.js
+++ b/src/routes/Catalogs/routes/CatalogsList/components/CatalogsListPage/CatalogsListPage.js
@@ -41,7 +41,7 @@ class CatalogsListPage extends React.PureComponent {
     return (
       <div className={styles.container} style={{ background: `url(${clouds}) bottom / 101% no-repeat, linear-gradient(to top, #41dcd7, #3083b2)` }}>
         <Helmet title={t('CatalogsListPage.documentTitle')} />
-        <Container>
+        <Container fluid>
           <h1>{t('CatalogsListPage.documentTitle')}</h1>
           <Loader isLoading={catalogs.pending} error={catalogs.error}>
             <div className={styles.catalogs}>


### PR DESCRIPTION
`<Container />` should be used everywhere.

It has a max width of 1200 px (already applied to every block on the home page).

Pass the `fluid` boolean prop (`<Container fluid />`) to have the container take all the available space (namely, 100%).