### PR TITLE
Fix overlapping tags on search page

### DIFF
--- a/src/components/Container/Container.scss
+++ b/src/components/Container/Container.scss
@@ -3,13 +3,4 @@
   width: 100%;
   margin: 0 auto;
   padding: 0 20px;
-
-  @media (min-width: 400px) {
-    width: 85%;
-    padding: 0;
-  }
-
-  @media (min-width: 550px) {
-    width: 80%;
-  }
 }

--- a/src/routes/Search/components/SearchPage/SearchPage.js
+++ b/src/routes/Search/components/SearchPage/SearchPage.js
@@ -6,6 +6,7 @@ import qs from 'querystring'
 
 import { unionWith, isEqual } from 'lodash'
 
+import Container from 'common/components/Container'
 import Loader from 'common/components/Loader'
 import SearchInput from 'common/components/SearchInput'
 
@@ -119,20 +120,22 @@ class SearchPage extends React.PureComponent {
       <div className={styles.container}>
         <Helmet title={t('SearchPage.documentTitle')} />
         <div className={styles.header} style={`background: url(${clouds}) bottom / 101% no-repeat, linear-gradient(to top, #41dcd7, #3083b2)`}>
-          <div className={styles.search}>
-            <SearchInput
-              defaultValue={search.parsedQuery.textInput}
-              onSearch={this.updateQuery}
-              hasButton
-            />
-            <FiltersSummary
-              filters={search.parsedQuery.filters}
-              removeFilter={this.removeFilter}
-            />
-          </div>
+          <Container fluid>
+            <div className={styles.search}>
+              <SearchInput
+                defaultValue={search.parsedQuery.textInput}
+                onSearch={this.updateQuery}
+                hasButton
+              />
+              <FiltersSummary
+                filters={search.parsedQuery.filters}
+                removeFilter={this.removeFilter}
+              />
+            </div>
+          </Container>
         </div>
 
-        <div className={styles.results}>
+        <Container fluid>
           <Loader isLoading={search.pending} error={search.error}>
             <SearchResults
               page={search.parsedQuery.page}
@@ -144,7 +147,7 @@ class SearchPage extends React.PureComponent {
               changePage={this.changePage}
             />
           </Loader>
-        </div>
+        </Container>
       </div>
     )
   }

--- a/src/routes/Search/components/SearchPage/SearchPage.scss
+++ b/src/routes/Search/components/SearchPage/SearchPage.scss
@@ -3,27 +3,15 @@
 }
 
 .header {
-  height: 240px;
+  padding: 4em 0;
 
-  @media (max-width: 551px) {
-    height: 110px;
+  @media (max-width: 768px) {
+    padding: 2em 0;
   }
 }
 
 .search {
-  padding: 4em 0 0 2em;
-  width: 80%;
-
-  @media (max-width: 551px) {
-    width: 100%;
-    padding: 0;
-  }
-}
-
-.results {
-  padding: 0 2em;
-
-  @media (max-width: 551px) {
-    padding: 0 1em;
+  @media (min-width: 961px) {
+    width: 80%;
   }
 }


### PR DESCRIPTION
Remove fixed heights.
Use container instead of custom left/right paddings.

Fix #529