### PR TITLE
Fix broken header CSS and fix z-index issues

### DIFF
--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -13,7 +13,7 @@
   right: 0;
   text-align: left;
   box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.2);
-  z-index: 1;
+  z-index: 2;
 
   div {
     color: $black;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -54,7 +54,7 @@ class Header extends React.Component {
     const login = <a href={logInUrl}>{t('components.Header.login')}</a>
 
     return (
-      <nav>
+      <nav className={styles.header}>
         <div className={styles.container}>
           <Link to={'/'}>
             <img className={styles.logo} src={logo} alt='Accueil de geo.data.gouv.fr' />

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -1,50 +1,44 @@
 @import 'variables';
 
-nav {
-  box-shadow: 0 1px 4px var(--box-dark-shadow);
+.header {
   width: 100%;
   background: #fff;
-  z-index: 100;
-
-  .container {
-    display: flex;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    align-items: center;
-  }
-
-  .logo {
-    height: 68px;
-    padding: 1em;
-  }
-
-  .links {
-    display: inline;
-    margin: 0;
-    padding: 1em;
-    list-style-type: 0;
-    text-align: right;
-
-    li {
-      padding: 0;
-      display: inline;
-    }
-
-    li + li {
-      padding-left: 15px;
-    }
-
-    a {
-      color: $black;
-    }
-  }
 }
 
-@media (max-width: 550px) {
-  nav {
-    .links {
-      padding-top: 0;
+.container {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.logo {
+  height: 68px;
+  padding: 1em;
+}
+
+.links {
+  display: inline;
+  margin: 0;
+  padding: 1em;
+  list-style-type: 0;
+  text-align: right;
+
+  li {
+    padding: 0;
+    display: inline;
+
+    + li {
+      padding-left: 15px;
     }
+  }
+
+  a {
+    color: $black;
+  }
+
+  @media (max-width: 550px) {
+    padding-top: 0;
   }
 }
 


### PR DESCRIPTION
- fix broken `z-index` on filters due to the changes to the header (random `z-index: 100`).
- remove global `nav` CSS as it would style `nav` elements all over the app.
- update dropdown `z-index` to be on top of the header


