### PR TITLE
Add top margin to search result footer on small devices

### DIFF
--- a/src/routes/Search/components/SearchResult/SearchResult.scss
+++ b/src/routes/Search/components/SearchResult/SearchResult.scss
@@ -111,6 +111,10 @@
 
 .footer {
   margin-top: auto;
+
+  @media (max-width: 768px) {
+    margin-top: 10px;
+  }
 }
 
 .infos > div:last-child {


### PR DESCRIPTION
<img width="627" alt="screen shot 2017-10-20 at 12 56 00 pm" src="https://user-images.githubusercontent.com/166147/31817878-21f508e2-b596-11e7-8a6e-2539940cf93a.png">
