### PR TITLE
Fix favicon paths

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -22,11 +22,11 @@
 
     <!-- Favicons -->
     <meta name="theme-color" content="#ffffff">
-    <link rel="apple-touch-icon" sizes="180x180" href="favicons/apple-icon-180x180.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="favicons/favicon-16x16.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="favicons/favicon-32x32.png">
-    <link rel="manifest" href="favicons/manifest.json">
-    <link rel="mask-icon" href="favicons/safari-pinned-tab.svg" color="#5bbad5">
+    <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-icon-180x180.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">
+    <link rel="manifest" href="/favicons/manifest.json">
+    <link rel="mask-icon" href="/favicons/safari-pinned-tab.svg" color="#5bbad5">
   </head>
   <body>
     <!--[if lt IE 10]>


### PR DESCRIPTION
Fix favicons not resolved in non-root routes.

```bash
win: geo.data.gouv.fr *tusbar/favicons > node
> url.resolve('https://geo.data.gouv.fr', 'favicons/apple-icon-180x180.png')
'https://geo.data.gouv.fr/favicons/apple-icon-180x180.png'

> url.resolve('https://geo.data.gouv.fr/catalogs/id', 'favicons/apple-icon-180x180.png')
'https://geo.data.gouv.fr/catalogs/favicons/apple-icon-180x180.png'
```