### PR TITLE
Make sure footer is sticking to the bottom

### DIFF
--- a/src/components/PageLayout/PageLayout.scss
+++ b/src/components/PageLayout/PageLayout.scss
@@ -1,13 +1,14 @@
 @import 'variables';
 
 .content {
-  flex-direction: column;
   display: flex;
+  flex-direction: column;
+  min-height: 100vh;
   position: relative;
 }
 
 .body {
+  flex: 1;
   z-index: 1;
   background-color: #fff;
-  min-height: 100vh;
 }


### PR DESCRIPTION
The previous behaviour would make the content of the page (excluding
header and footer) 100vh minimum. The issue with that is that we would
always have a scroll on small pages of the size of the header.

This allows to have the footer visible on pages with little content.

`flex: 1` allows the content of the page to grow, hence push the footer
to the bottom.