### PR TITLE
Fix missing blockquote markdown parsing

### DIFF
--- a/src/components/MarkdownSummary.js
+++ b/src/components/MarkdownSummary.js
@@ -33,6 +33,7 @@ class Renderer {
   list = body => body
   heading = body => this.paragraph(body)
   code = body => this.paragraph(body)
+  blockquote = body => this.paragraph(body)
   listitem = body => this.paragraph(body)
 
   link = href => href


### PR DESCRIPTION
For some reason blockquotes were left out in the markdown summary component.

This fixes that.