### PR TITLE
Fix IE11 support

### DIFF
--- a/components/content.js
+++ b/components/content.js
@@ -13,7 +13,7 @@ const Content = ({ children, clouds }) => (
         padding: 20px 0;
         display: flex;
         flex-direction: column;
-        flex: 1;
+        flex: auto;
       }
 
       .clouds {

--- a/components/facet.js
+++ b/components/facet.js
@@ -134,7 +134,7 @@ class Facet extends React.Component {
 
           .facet {
             display: flex;
-            flex: 1;
+            flex: auto;
             background: $lightgrey;
             border-radius: 3px 0 0 3px;
             height: 26px;

--- a/package.json
+++ b/package.json
@@ -71,6 +71,9 @@
     "styled-jsx-plugin-sass": "^0.2.2",
     "webpack-bundle-analyzer": "^2.9.1"
   },
+  "browserslist": [
+    "> 1%"
+  ],
   "engines": {
     "node": "8.x",
     "yarn": "1.x"

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import Document, { Head, Main, NextScript } from 'next/document'
+import flush from 'styled-jsx/server'
+
+export default class MyDocument extends Document {
+  static getInitialProps({ renderPage }) {
+    const { html, head, errorHtml, chunks } = renderPage()
+    const styles = flush()
+    return { html, head, errorHtml, chunks, styles }
+  }
+
+  render() {
+    return (
+      <html>
+        <Head />
+        <body>
+          <Main />
+          <script src='https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es7' />
+          <NextScript />
+        </body>
+      </html>
+    )
+  }
+}

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -15,7 +15,7 @@ export default class MyDocument extends Document {
         <Head />
         <body>
           <Main />
-          <script src='https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es7' />
+          <script src='https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6,es7' />
           <NextScript />
         </body>
       </html>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -15,7 +15,7 @@ export default class MyDocument extends Document {
         <Head />
         <body>
           <Main />
-          <script src='https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6,es7' />
+          <script src='https://cdn.polyfill.io/v2/polyfill.min.js?features=default,modernizr:es6array,modernizr:es7array' />
           <NextScript />
         </body>
       </html>

--- a/pages/dataset.js
+++ b/pages/dataset.js
@@ -216,7 +216,7 @@ class DatasetPage extends React.Component {
           .container {
             display: flex;
             flex-wrap: wrap;
-            flex: 1;
+            flex: auto;
 
             @media (max-width: 768px) {
               flex-direction: column;


### PR DESCRIPTION
- Add polyfills for es6 + es7 arrays.
- Fix min-height issues with flexbox.

Maybe we should release 3.0.1 after this and re-deploy.