### PR TITLE
Fix fr characters issues on newsletter title in firefox

### DIFF
--- a/locales/fr/home.json
+++ b/locales/fr/home.json
@@ -8,7 +8,7 @@
   "eventsLink": "Voir nos événements",
 
   "newsletter": {
-    "title": "Pour être informé des nouveautés, inscrivez-vous à notre newsletter :",
+    "title": "Pour être informé des nouveautés, inscrivez-vous à notre newsletter :",
     "placeholder": "Votre adresse email",
     "button": "Inscription"
   }


### PR DESCRIPTION
This fixes this:

<img width="724" alt="screen shot 2017-12-11 at 12 54 56 pm" src="https://user-images.githubusercontent.com/166147/33829929-88667962-de72-11e7-8da6-b14d08a7fee6.png">
