### PR TITLE
Update linting rules

### DIFF
--- a/components/box.js
+++ b/components/box.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 const Box = ({children, title, padded, color}) => (

--- a/components/button.js
+++ b/components/button.js
@@ -5,8 +5,6 @@ const Button = ({children, type, size, color, href, disabled, block, ...props}) 
   const buttonProps = href ? {} : props
 
   return (
-    // Button does have a type, but eslint is broken.
-    // eslint-disable-next-line react/button-has-type
     <button
       type={type}
       disabled={disabled}

--- a/components/button.js
+++ b/components/button.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 const Button = ({children, type, size, color, href, disabled, block, ...props}) => {

--- a/components/catalog-preview.js
+++ b/components/catalog-preview.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import {translate} from 'react-i18next'
 import {get} from 'lodash'

--- a/components/catalog/harvests/delta.js
+++ b/components/catalog/harvests/delta.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import UpIcon from 'react-icons/lib/fa/long-arrow-up'

--- a/components/catalog/harvests/histogram.js
+++ b/components/catalog/harvests/histogram.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import {translate} from 'react-i18next'
 import {Line} from 'react-chartjs-2'

--- a/components/catalog/harvests/row.js
+++ b/components/catalog/harvests/row.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
 import {translate} from 'react-i18next'

--- a/components/catalog/harvests/table.js
+++ b/components/catalog/harvests/table.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import {translate} from 'react-i18next'
 

--- a/components/catalog/header.js
+++ b/components/catalog/header.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import {translate} from 'react-i18next'
 

--- a/components/catalog/organizations.js
+++ b/components/catalog/organizations.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import Facet from '../facet'

--- a/components/catalog/pie.js
+++ b/components/catalog/pie.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import {translate} from 'react-i18next'
 import {Pie} from 'react-chartjs-2'

--- a/components/catalog/statistics.js
+++ b/components/catalog/statistics.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import {translate} from 'react-i18next'
 import {get} from 'lodash'

--- a/components/contact.js
+++ b/components/contact.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import {translate} from 'react-i18next'
 import PropTypes from 'prop-types'
 

--- a/components/container.js
+++ b/components/container.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 const Container = ({children, fluid}) => (

--- a/components/content.js
+++ b/components/content.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 const Content = ({children, clouds}) => (

--- a/components/counter.js
+++ b/components/counter.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 const Counter = ({value, label, unit, size, color, title}) => (

--- a/components/dataset/contacts.js
+++ b/components/dataset/contacts.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import {translate} from 'react-i18next'
 

--- a/components/dataset/datagouv/check.js
+++ b/components/dataset/datagouv/check.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import CheckIcon from 'react-icons/lib/fa/check'

--- a/components/dataset/datagouv/distribution-check.js
+++ b/components/dataset/datagouv/distribution-check.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import {translate} from 'react-i18next'
 import PropTypes from 'prop-types'
 

--- a/components/dataset/datagouv/producer-check.js
+++ b/components/dataset/datagouv/producer-check.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import {translate} from 'react-i18next'
 import PropTypes from 'prop-types'
 

--- a/components/dataset/discussions/list.js
+++ b/components/dataset/discussions/list.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import {flowRight} from 'lodash'
 import {translate} from 'react-i18next'

--- a/components/dataset/discussions/message.js
+++ b/components/dataset/discussions/message.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
 

--- a/components/dataset/downloads/preview-table.js
+++ b/components/dataset/downloads/preview-table.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import Head from 'next/head'
 import Table from 'react-table'

--- a/components/dataset/header/index.js
+++ b/components/dataset/header/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import {translate} from 'react-i18next'
 

--- a/components/dataset/header/infos.js
+++ b/components/dataset/header/infos.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
 import {translate} from 'react-i18next'

--- a/components/dataset/header/life-cycle.js
+++ b/components/dataset/header/life-cycle.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
 import {translate} from 'react-i18next'

--- a/components/dataset/links.js
+++ b/components/dataset/links.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 const Links = ({links}) => (

--- a/components/dataset/metadata.js
+++ b/components/dataset/metadata.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
 import {translate} from 'react-i18next'

--- a/components/dataset/producer.js
+++ b/components/dataset/producer.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import withFetch from '../hoc/with-fetch'

--- a/components/dataset/spatial-extent.js
+++ b/components/dataset/spatial-extent.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import dynamic from 'next/dynamic'
 import {translate} from 'react-i18next'

--- a/components/event.js
+++ b/components/event.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
 import {translate} from 'react-i18next'

--- a/components/harvest-status.js
+++ b/components/harvest-status.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
 import {translate} from 'react-i18next'

--- a/components/harvest/header.js
+++ b/components/harvest/header.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import {translate} from 'react-i18next'
 

--- a/components/harvest/logs.js
+++ b/components/harvest/logs.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import {translate} from 'react-i18next'
 

--- a/components/home/catalogs-list.js
+++ b/components/home/catalogs-list.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import {flowRight} from 'lodash'
 import {translate} from 'react-i18next'

--- a/components/home/catalogs.js
+++ b/components/home/catalogs.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import {translate} from 'react-i18next'
 

--- a/components/home/events.js
+++ b/components/home/events.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import {translate} from 'react-i18next'
 

--- a/components/home/hero.js
+++ b/components/home/hero.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import {translate} from 'react-i18next'
 

--- a/components/home/section.js
+++ b/components/home/section.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import Container from '../container'

--- a/components/info.js
+++ b/components/info.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import InfoIcon from 'react-icons/lib/fa/info-circle'

--- a/components/link.js
+++ b/components/link.js
@@ -1,5 +1,3 @@
-
-import React from 'react'
 import PropTypes from 'prop-types'
 import NextLink from 'next/link'
 

--- a/components/markdown-summary.js
+++ b/components/markdown-summary.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import prune from 'underscore.string/prune'
 

--- a/components/markdown.js
+++ b/components/markdown.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import marked from 'marked'
 

--- a/components/meta.js
+++ b/components/meta.js
@@ -1,4 +1,4 @@
-import React, {Fragment} from 'react'
+import {Fragment} from 'react'
 import PropTypes from 'prop-types'
 import Head from 'next/head'
 import prune from 'underscore.string/prune'

--- a/components/page/footer/index.js
+++ b/components/page/footer/index.js
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import Container from '../../container'
 import Social from './social'
 import Sitemap from './sitemap'

--- a/components/page/footer/sitemap.js
+++ b/components/page/footer/sitemap.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import {translate} from 'react-i18next'
 

--- a/components/page/footer/social.js
+++ b/components/page/footer/social.js
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const Social = () => (
   <ul className='social'>
     <li>

--- a/components/page/index.js
+++ b/components/page/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
 import NProgress from 'nprogress'

--- a/components/percent.js
+++ b/components/percent.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import Counter from './counter'

--- a/components/publication/breadcrumbs.js
+++ b/components/publication/breadcrumbs.js
@@ -1,4 +1,4 @@
-import React, {Fragment} from 'react'
+import {Fragment} from 'react'
 import PropTypes from 'prop-types'
 
 import Link from '../link'

--- a/components/publication/header.js
+++ b/components/publication/header.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import Link from '../link'

--- a/components/publication/organization-preview.js
+++ b/components/publication/organization-preview.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import Link from '../link'

--- a/components/publication/organization/dataset-metrics.js
+++ b/components/publication/organization/dataset-metrics.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import withFetch from '../../hoc/with-fetch'

--- a/components/publication/organization/source-producers.js
+++ b/components/publication/organization/source-producers.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import withFetch from '../../hoc/with-fetch'

--- a/components/search/active-facets.js
+++ b/components/search/active-facets.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import Facet from '../facet'

--- a/components/search/count.js
+++ b/components/search/count.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import {translate} from 'react-i18next'
 

--- a/components/search/facet-button.js
+++ b/components/search/facet-button.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import FilterIcon from 'react-icons/lib/fa/filter'

--- a/components/search/result/footer.js
+++ b/components/search/result/footer.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
 import {translate} from 'react-i18next'

--- a/components/search/result/index.js
+++ b/components/search/result/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import {translate} from 'react-i18next'
 

--- a/components/search/result/thumbnail.js
+++ b/components/search/result/thumbnail.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import {GEODATA_API_URL} from '@env'

--- a/components/search/results.js
+++ b/components/search/results.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import Result from './result'

--- a/components/success.js
+++ b/components/success.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import SuccessIcon from 'react-icons/lib/fa/check-circle'

--- a/components/warning.js
+++ b/components/warning.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import WarningIcon from 'react-icons/lib/fa/exclamation-triangle'

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "cross-env": "^5.1.1",
     "enzyme": "^3.2.0",
     "enzyme-adapter-react-16": "^1.1.0",
-    "eslint-config-xo-nextjs": "^1.0.0",
+    "eslint-config-xo-nextjs": "^1.1.1",
     "eslint-plugin-react": "^7.5.1",
     "jest": "^21.2.1",
     "jest-junit": "^3.4.0",

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import Document, {Head, Main, NextScript} from 'next/document'
 import flush from 'styled-jsx/server'
 

--- a/pages/events.js
+++ b/pages/events.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import {flowRight} from 'lodash'
 

--- a/pages/legal.js
+++ b/pages/legal.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import {flowRight} from 'lodash'
 
 import attachI18n from '../components/hoc/attach-i18n'

--- a/pages/publication/index.js
+++ b/pages/publication/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import {flowRight} from 'lodash'
 
 import attachI18n from '../../components/hoc/attach-i18n'

--- a/tests/components/container.test.js
+++ b/tests/components/container.test.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import renderer from 'react-test-renderer'
 import {shallow} from 'enzyme'
 

--- a/tests/components/info.test.js
+++ b/tests/components/info.test.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import renderer from 'react-test-renderer'
 
 import Info from '../../components/info'

--- a/tests/components/success.test.js
+++ b/tests/components/success.test.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import renderer from 'react-test-renderer'
 
 import Success from '../../components/success'

--- a/tests/components/warning.test.js
+++ b/tests/components/warning.test.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import renderer from 'react-test-renderer'
 
 import Warning from '../../components/warning'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2531,9 +2531,9 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-config-xo-nextjs@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-xo-nextjs/-/eslint-config-xo-nextjs-1.0.0.tgz#54228f267a9a430e1126ce8cb1993edafc70cec8"
+eslint-config-xo-nextjs@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-xo-nextjs/-/eslint-config-xo-nextjs-1.1.1.tgz#3200b2a727a02061ae107c042e0f2edb8f1f6ab7"
   dependencies:
     eslint-config-xo-react "^0.15.0"
 


### PR DESCRIPTION
- Next.js auto-imports `react`, so we removed all unnecessary imports.
- Disabled `react/button-has-type` as it does not work with props.