### PR TITLE
Update next.js to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lodash-es": "^4.17.4",
     "marked": "^0.3.7",
     "moment": "^2.19.4",
-    "next": "^4.2.1",
+    "next": "^4.2.3",
     "node-sass": "^4.7.2",
     "nprogress": "^0.2.0",
     "prop-types": "^15.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5250,9 +5250,9 @@ netrc@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
 
-next@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/next/-/next-4.2.1.tgz#37b5637050235b92a487ca484e20088ace7e37fe"
+next@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/next/-/next-4.2.3.tgz#6f85f9bd6df2c420b4f6425f9f158e82515b7bc8"
   dependencies:
     ansi-html "0.0.7"
     babel-core "6.26.0"


### PR DESCRIPTION
Fix for CVE-2018-6184.

See https://github.com/zeit/next.js/releases/tag/4.2.3