### PR TITLE
Move doc and publication pages up

### DIFF
--- a/pages/doc.js
+++ b/pages/doc.js
@@ -3,15 +3,15 @@ import PropTypes from 'prop-types'
 import {flowRight} from 'lodash'
 import FaBook from 'react-icons/lib/fa/book'
 
-import attachI18n from '../../components/hoc/attach-i18n'
-import attachSession from '../../components/hoc/attach-session'
+import attachI18n from '../components/hoc/attach-i18n'
+import attachSession from '../components/hoc/attach-session'
 
-import Page from '../../components/page'
-import Meta from '../../components/meta'
-import Head from '../../components/head'
-import Content from '../../components/content'
-import Container from '../../components/container'
-import Link from '../../components/link'
+import Page from '../components/page'
+import Meta from '../components/meta'
+import Head from '../components/head'
+import Content from '../components/content'
+import Container from '../components/container'
+import Link from '../components/link'
 
 class DocumentationPage extends React.Component {
   static propTypes = {

--- a/pages/publication.js
+++ b/pages/publication.js
@@ -1,18 +1,18 @@
 import React from 'react'
 import {flowRight} from 'lodash'
 
-import attachI18n from '../../components/hoc/attach-i18n'
-import attachSession from '../../components/hoc/attach-session'
+import attachI18n from '../components/hoc/attach-i18n'
+import attachSession from '../components/hoc/attach-session'
 
-import Page from '../../components/page'
-import Meta from '../../components/meta'
-import Content from '../../components/content'
-import Container from '../../components/container'
-import RequireAuth from '../../components/require-auth'
+import Page from '../components/page'
+import Meta from '../components/meta'
+import Content from '../components/content'
+import Container from '../components/container'
+import RequireAuth from '../components/require-auth'
 
-import Header from '../../components/publication/header'
-import Breadcrumbs from '../../components/publication/breadcrumbs'
-import OrganizationPreview from '../../components/publication/organization-preview'
+import Header from '../components/publication/header'
+import Breadcrumbs from '../components/publication/breadcrumbs'
+import OrganizationPreview from '../components/publication/organization-preview'
 
 const renderAuth = user => (
   <div>


### PR DESCRIPTION
index.js should be avoided because it creates just one `index.js` bundle with unrelated stuff.