### PR TITLE
Use runtime configuration instead of babel-based config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,18 +3,6 @@
     ["inline-import", {
       "extensions": [".css"]
     }],
-    ["dotenv-import", {
-      "allowUndefined": true,
-      "whitelist": [
-        "PUBLIC_URL",
-        "PUBLICATION_BASE_URL",
-        "DATAGOUV_API_URL",
-        "DATAGOUV_API_KEY",
-        "GEODATA_API_URL",
-        "PIWIK_URL",
-        "PIWIK_SITE_ID"
-      ]
-    }],
     "lodash"
   ],
 

--- a/components/dataset/discussions/index.js
+++ b/components/dataset/discussions/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {translate} from 'react-i18next'
+import getConfig from 'next/config'
 
 import CommentIcon from 'react-icons/lib/fa/comments'
 
@@ -12,7 +13,9 @@ import RequireAuth from '../../require-auth'
 import Form from './form'
 import List from './list'
 
-import {DATAGOUV_API_URL} from '@env'
+const {publicRuntimeConfig: {
+  DATAGOUV_API_URL
+}} = getConfig()
 
 class Discussions extends React.Component {
   static propTypes = {

--- a/components/dataset/downloads/dataset-download.js
+++ b/components/dataset/downloads/dataset-download.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import {translate} from 'react-i18next'
+import getConfig from 'next/config'
 import PropTypes from 'prop-types'
 import strRightBack from 'underscore.string/strRightBack'
 
@@ -10,7 +11,9 @@ import formats from '../../../lib/formats'
 
 import Button from '../../button'
 
-import {GEODATA_API_URL} from '@env'
+const {publicRuntimeConfig: {
+  GEODATA_API_URL
+}} = getConfig()
 
 class DatasetDownload extends React.PureComponent {
   static propTypes = {

--- a/components/dataset/thumbnails.js
+++ b/components/dataset/thumbnails.js
@@ -1,8 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {uniqBy} from 'lodash'
+import getConfig from 'next/config'
 
-import {GEODATA_API_URL} from '@env'
+const {publicRuntimeConfig: {
+  GEODATA_API_URL
+}} = getConfig()
 
 class Thumbnails extends React.Component {
   static propTypes = {

--- a/components/meta.js
+++ b/components/meta.js
@@ -1,12 +1,15 @@
 import React, {Fragment} from 'react'
 import PropTypes from 'prop-types'
+import getConfig from 'next/config'
 import Head from 'next/head'
 import prune from 'underscore.string/prune'
 import {flowRight} from 'lodash'
 import {translate} from 'react-i18next'
 import {withRouter} from 'next/router'
 
-import {PUBLIC_URL} from '@env'
+const {publicRuntimeConfig: {
+  PUBLIC_URL
+}} = getConfig()
 
 const SITE_NAME = 'geo.data.gouv.fr'
 const TWITTER_HANDLE = '@geodatagouv'

--- a/components/page/header/index.js
+++ b/components/page/header/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import getConfig from 'next/config'
 import {flowRight} from 'lodash'
 import {withRouter} from 'next/router'
 import {translate} from 'react-i18next'
@@ -10,7 +11,10 @@ import Container from '../../container'
 import Link from '../../link'
 import LanguageSelection from './language-selection'
 
-import {PUBLIC_URL, PUBLICATION_BASE_URL} from '@env'
+const {publicRuntimeConfig: {
+  PUBLIC_URL,
+  PUBLICATION_BASE_URL
+}} = getConfig()
 
 class Header extends React.Component {
   static propTypes = {

--- a/components/page/piwik.js
+++ b/components/page/piwik.js
@@ -1,7 +1,11 @@
 import React from 'react'
+import getConfig from 'next/config'
 import Head from 'next/head'
 
-import {PIWIK_URL, PIWIK_SITE_ID} from '@env'
+const {publicRuntimeConfig: {
+  PIWIK_URL,
+  PIWIK_SITE_ID
+}} = getConfig()
 
 class Piwik extends React.Component {
   componentDidMount() {

--- a/components/require-auth.js
+++ b/components/require-auth.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {flowRight} from 'lodash'
 import {withRouter} from 'next/router'
+import getConfig from 'next/config'
 import {translate} from 'react-i18next'
 
 import withSession from './hoc/with-session'
@@ -9,7 +10,10 @@ import withSession from './hoc/with-session'
 import Info from './info'
 import Button from './button'
 
-import {PUBLIC_URL, PUBLICATION_BASE_URL} from '@env'
+const {publicRuntimeConfig: {
+  PUBLIC_URL,
+  PUBLICATION_BASE_URL
+}} = getConfig()
 
 class RequireAuth extends React.Component {
   static propTypes = {

--- a/components/search/result/thumbnail.js
+++ b/components/search/result/thumbnail.js
@@ -1,7 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import getConfig from 'next/config'
 
-import {GEODATA_API_URL} from '@env'
+const {publicRuntimeConfig: {
+  GEODATA_API_URL
+}} = getConfig()
 
 const Thumbnail = ({recordId, thumbnails}) => {
   const hasThumbnail = thumbnails && thumbnails.length > 0

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -5,5 +5,12 @@ import 'mock-local-storage'
 
 import {configure} from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
+import {setConfig} from 'next/config'
 
 configure({adapter: new Adapter()})
+
+// Initialize Next.js configuration with empty values.
+setConfig({
+  publicRuntimeConfig: {},
+  secretRuntimeConfig: {}
+})

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,6 +1,11 @@
+import getConfig from 'next/config'
 import 'isomorphic-unfetch' // eslint-disable-line import/no-unassigned-import
 
-import {DATAGOUV_API_URL, DATAGOUV_API_KEY, PUBLICATION_BASE_URL} from '@env'
+const {publicRuntimeConfig: {
+  DATAGOUV_API_URL,
+  DATAGOUV_API_KEY,
+  PUBLICATION_BASE_URL
+}} = getConfig()
 
 class HttpError extends Error {
   constructor(response) {

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,6 +1,10 @@
+import getConfig from 'next/config'
+
 import {_get} from './fetch'
 
-import {PUBLICATION_BASE_URL} from '@env'
+const {publicRuntimeConfig: {
+  PUBLICATION_BASE_URL
+}} = getConfig()
 
 const SESSION_KEY = 'geo-dgv-session'
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 const {join} = require('path')
 const webpack = require('webpack')
+const nextRuntimeDotenv = require('next-runtime-dotenv')
 const {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer')
 
 // The following dependencies will be pushed to the commons.js bundle
@@ -12,7 +13,19 @@ const commonDependencies = [
   '/pages/_error.js'
 ]
 
-module.exports = {
+const withConfig = nextRuntimeDotenv({
+  public: [
+    'PUBLIC_URL',
+    'DATAGOUV_API_URL',
+    'DATAGOUV_API_KEY',
+    'PUBLICATION_BASE_URL',
+    'GEODATA_API_URL',
+    'PIWIK_URL',
+    'PIWIK_SITE_ID'
+  ]
+})
+
+module.exports = withConfig({
   webpack(config, {dev, isServer}) {
     config.plugins.push(
       new webpack.ContextReplacementPlugin(/moment[/\\]locale$/, /fr/)
@@ -54,4 +67,4 @@ module.exports = {
 
     return config
   }
-}
+})

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "marked": "^0.3.18",
     "moment": "^2.19.4",
     "next": "^5.1.0",
+    "next-runtime-dotenv": "^1.0.0",
     "nprogress": "^0.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
@@ -42,7 +43,6 @@
   },
   "devDependencies": {
     "babel-eslint": "^8.2.2",
-    "babel-plugin-dotenv-import": "^1.3.1",
     "babel-plugin-inline-import": "^2.0.6",
     "babel-plugin-lodash": "^3.3.2",
     "codecov": "^3.0.0",
@@ -99,15 +99,7 @@
     "space": 2,
     "env": "browser",
     "rules": {
-      "camelcase": "warn",
-      "import/no-unresolved": [
-        "error",
-        {
-          "ignore": [
-            "@env"
-          ]
-        }
-      ]
+      "camelcase": "warn"
     },
     "overrides": [
       {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "marked": "^0.3.18",
     "moment": "^2.19.4",
     "next": "^5.1.0",
-    "next-runtime-dotenv": "^1.0.0",
+    "next-runtime-dotenv": "^1.0.1",
     "nprogress": "^0.2.0",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",

--- a/pages/catalog.js
+++ b/pages/catalog.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {flowRight} from 'lodash'
+import getConfig from 'next/config'
 
 import {_get, _post} from '../lib/fetch'
 import {isObsolete} from '../lib/catalog'
@@ -22,7 +23,9 @@ import Statistics from '../components/catalog/statistics'
 import Harvests from '../components/catalog/harvests'
 import Organizations from '../components/catalog/organizations'
 
-import {GEODATA_API_URL} from '@env'
+const {publicRuntimeConfig: {
+  GEODATA_API_URL
+}} = getConfig()
 
 class CatalogPage extends React.Component {
   static propTypes = {

--- a/pages/catalogs.js
+++ b/pages/catalogs.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {flowRight} from 'lodash'
+import getConfig from 'next/config'
 
 import {_get} from '../lib/fetch'
 import {sortByScore} from '../lib/catalog'
@@ -15,7 +16,9 @@ import Content from '../components/content'
 import Container from '../components/container'
 import CatalogPreview from '../components/catalog-preview'
 
-import {GEODATA_API_URL} from '@env'
+const {publicRuntimeConfig: {
+  GEODATA_API_URL
+}} = getConfig()
 
 class CatalogsPage extends React.Component {
   static propTypes = {

--- a/pages/dataset.js
+++ b/pages/dataset.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import getConfig from 'next/config'
 import {uniqWith, isEqual, flowRight} from 'lodash'
 
 import {_get} from '../lib/fetch'
@@ -28,7 +29,10 @@ import Links from '../components/dataset/links'
 
 import Metadata from '../components/dataset/metadata'
 
-import {GEODATA_API_URL, DATAGOUV_API_URL} from '@env'
+const {publicRuntimeConfig: {
+  GEODATA_API_URL,
+  DATAGOUV_API_URL
+}} = getConfig()
 
 class DatasetPage extends React.Component {
   static propTypes = {

--- a/pages/harvest.js
+++ b/pages/harvest.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {flowRight} from 'lodash'
+import getConfig from 'next/config'
 
 import {_get} from '../lib/fetch'
 
@@ -18,7 +19,9 @@ import HarvestStatus from '../components/harvest-status'
 import Header from '../components/harvest/header'
 import Logs from '../components/harvest/logs'
 
-import {GEODATA_API_URL} from '@env'
+const {publicRuntimeConfig: {
+  GEODATA_API_URL
+}} = getConfig()
 
 class HarvestPage extends React.Component {
   static propTypes = {

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import {flowRight} from 'lodash'
+import getConfig from 'next/config'
 
 import attachI18n from '../components/hoc/attach-i18n'
 import attachSession from '../components/hoc/attach-session'
@@ -15,7 +16,9 @@ import Catalogs from '../components/home/catalogs'
 import Events from '../components/home/events'
 import NewsletterForm from '../components/home/newsletter-form'
 
-import {GEODATA_API_URL} from '@env'
+const {publicRuntimeConfig: {
+  GEODATA_API_URL
+}} = getConfig()
 
 class IndexPage extends React.Component {
   state = {}

--- a/pages/publication/datasets.js
+++ b/pages/publication/datasets.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {flowRight} from 'lodash'
+import getConfig from 'next/config'
 
 import {_get, _put} from '../../lib/fetch'
 
@@ -18,7 +19,9 @@ import Header from '../../components/publication/header'
 import Breadcrumbs from '../../components/publication/breadcrumbs'
 import Datasets from '../../components/publication/datasets'
 
-import {PUBLICATION_BASE_URL} from '@env'
+const {publicRuntimeConfig: {
+  PUBLICATION_BASE_URL
+}} = getConfig()
 
 class DatasetsPublicationPage extends React.Component {
   static propTypes = {

--- a/pages/publication/organization.js
+++ b/pages/publication/organization.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {flowRight} from 'lodash'
+import getConfig from 'next/config'
 
 import {_get, _put} from '../../lib/fetch'
 
@@ -21,7 +22,10 @@ import SourceCatalogs from '../../components/publication/organization/source-cat
 import SourceProducers from '../../components/publication/organization//source-producers'
 import DatasetMetrics from '../../components/publication/organization//dataset-metrics'
 
-import {PUBLICATION_BASE_URL, GEODATA_API_URL} from '@env'
+const {publicRuntimeConfig: {
+  PUBLICATION_BASE_URL,
+  GEODATA_API_URL
+}} = getConfig()
 
 class OrganizationPublicationPage extends React.Component {
   static propTypes = {

--- a/pages/publication/producers.js
+++ b/pages/publication/producers.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {flowRight} from 'lodash'
+import getConfig from 'next/config'
 
 import {_get, _post, _delete} from '../../lib/fetch'
 
@@ -18,7 +19,9 @@ import Header from '../../components/publication/header'
 import Breadcrumbs from '../../components/publication/breadcrumbs'
 import Producers from '../../components/publication/producers'
 
-import {PUBLICATION_BASE_URL} from '@env'
+const {publicRuntimeConfig: {
+  PUBLICATION_BASE_URL
+}} = getConfig()
 
 class ProducersPublicationPage extends React.Component {
   static propTypes = {

--- a/pages/search.js
+++ b/pages/search.js
@@ -2,6 +2,7 @@ import {stringify} from 'querystring'
 import React from 'react'
 import PropTypes from 'prop-types'
 import {flowRight} from 'lodash'
+import getConfig from 'next/config'
 
 import {_get} from '../lib/fetch'
 import {getFilters} from '../lib/query'
@@ -23,7 +24,9 @@ import Paging from '../components/search/paging'
 import Facets from '../components/search/facets'
 import FacetButton from '../components/search/facet-button'
 
-import {GEODATA_API_URL} from '@env'
+const {publicRuntimeConfig: {
+  GEODATA_API_URL
+}} = getConfig()
 
 class SearchPage extends React.Component {
   static propTypes = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -684,12 +684,6 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-dotenv-import@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-dotenv-import/-/babel-plugin-dotenv-import-1.3.1.tgz#54e515d47aed18d15717d22e82b09552d2da0df7"
-  dependencies:
-    dotenv "^4.0.0"
-
 babel-plugin-inline-import@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-inline-import/-/babel-plugin-inline-import-2.0.6.tgz#8a3c179561b503bf4af319f3cad435e6b7b2863c"
@@ -2307,9 +2301,9 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
-dotenv@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
+dotenv@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
 
 duplexer3@^0.1.4:
   version "0.1.4"
@@ -5357,6 +5351,12 @@ nearley@^2.7.10:
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+next-runtime-dotenv@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/next-runtime-dotenv/-/next-runtime-dotenv-1.0.0.tgz#2f7e39d5f6f369c8173989d6fc2c86060afacf94"
+  dependencies:
+    dotenv "^5.0.1"
 
 next@^5.1.0:
   version "5.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5352,9 +5352,9 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
-next-runtime-dotenv@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/next-runtime-dotenv/-/next-runtime-dotenv-1.0.0.tgz#2f7e39d5f6f369c8173989d6fc2c86060afacf94"
+next-runtime-dotenv@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/next-runtime-dotenv/-/next-runtime-dotenv-1.0.1.tgz#46c57b0d28c7788a79da8ae07fea0db243a2072e"
   dependencies:
     dotenv "^5.0.1"
 


### PR DESCRIPTION
This uses the new runtime configuration system from Next.js 5.1.0.

It uses https://github.com/tusbar/next-runtime-dotenv that exposes env variables in next.js’s config system.

We’re only using `public` variables for now.

Variables are whitelisted in `next.config.js`.

This allows to change the configuration without rebuilding everything. Also it will prevent us from having issues with babel-loader cache.