### PR TITLE
Flip preview data when coordinates are flipped

### DIFF
--- a/__tests__/lib/geo/bbox.js
+++ b/__tests__/lib/geo/bbox.js
@@ -1,0 +1,52 @@
+import {diffBbox, flipBbox, isBboxFlipped} from '../../../lib/geo/bbox'
+
+describe('diffBbox', () => {
+  it('should return 0 for equal bboxes', () => {
+    const bbox = [164.6188, -22.37823333, 166.8929, -20.97443333]
+
+    expect(diffBbox(bbox, bbox)).toBe(0)
+  })
+
+  it('should return a positive number for different bboxes', () => {
+    const bbox1 = [164.6188, -22.37823333, 166.8929, -20.97443333]
+    const bbox2 = [163.983, -22.6739, 168.131, -20.0879]
+
+    expect(diffBbox(bbox1, bbox2)).toBeGreaterThan(0)
+  })
+
+  it('should return a higher number for very different bboxes', () => {
+    const bbox1 = [164.6188, -22.37823333, 166.8929, -20.97443333]
+    const bbox2 = [163.983, -22.6739, 168.131, -20.0879]
+    const bbox3 = [-22.37823333, 164.6188, -20.97443333, 166.8929]
+
+    const similar = diffBbox(bbox1, bbox2)
+    const different = diffBbox(bbox1, bbox3)
+
+    expect(similar).toBeLessThan(different)
+  })
+})
+
+describe('flipBbox', () => {
+  it('should flip the coordinates of a bbox', () => {
+    const bbox1 = [164.6188, -22.37823333, 166.8929, -20.97443333]
+    const bbox2 = [-22.37823333, 164.6188, -20.97443333, 166.8929]
+
+    expect(flipBbox(bbox1)).toEqual(bbox2)
+  })
+})
+
+describe('isBboxFlipped', () => {
+  it('should return false for similar bboxes', () => {
+    const bbox1 = [164.6188, -22.37823333, 166.8929, -20.97443333]
+    const bbox2 = [163.983, -22.6739, 168.131, -20.0879]
+
+    expect(isBboxFlipped(bbox1, bbox2)).toBe(false)
+  })
+
+  it('should return true for flipped bboxes', () => {
+    const bbox = [164.6188, -22.37823333, 166.8929, -20.97443333]
+    const flipped = flipBbox(bbox)
+
+    expect(isBboxFlipped(bbox, flipped)).toBe(true)
+  })
+})

--- a/components/dataset/downloads/index.js
+++ b/components/dataset/downloads/index.js
@@ -14,7 +14,13 @@ class Downloads extends React.Component {
       location: PropTypes.string
     })).isRequired,
 
+    extent: PropTypes.object,
+
     t: PropTypes.func.isRequired
+  }
+
+  static defaultProps = {
+    extent: null
   }
 
   state = {}
@@ -36,7 +42,7 @@ class Downloads extends React.Component {
   }
 
   render() {
-    const {distributions, t} = this.props
+    const {distributions, extent, t} = this.props
     const {preview} = this.state
 
     if (distributions.length === 0) {
@@ -61,6 +67,7 @@ class Downloads extends React.Component {
               <Preview
                 title={preview.name}
                 link={preview.link}
+                extent={extent}
                 onClose={this.clearPreview}
               />
             )}

--- a/components/dataset/downloads/preview.js
+++ b/components/dataset/downloads/preview.js
@@ -25,8 +25,13 @@ class Preview extends React.Component {
   static propTypes = {
     title: PropTypes.string.isRequired,
     link: PropTypes.string.isRequired,
+    extent: PropTypes.object,
     onClose: PropTypes.func.isRequired,
     t: PropTypes.func.isRequired
+  }
+
+  static defaultProps = {
+    extent: null
   }
 
   state = {
@@ -60,7 +65,7 @@ class Preview extends React.Component {
   }
 
   render() {
-    const {title, onClose, t} = this.props
+    const {title, extent, onClose, t} = this.props
     const {loading, data, view, error} = this.state
 
     return (
@@ -88,7 +93,7 @@ class Preview extends React.Component {
               <div className='map-wrapper'>
                 {view === 'map' ? (
                   <div className='map'>
-                    <CenteredMap data={data} />
+                    <CenteredMap data={data} extent={extent} />
                   </div>
                 ) : (
                   <PreviewTable data={data} />

--- a/lib/geo/bbox.js
+++ b/lib/geo/bbox.js
@@ -1,0 +1,34 @@
+// Compute the absolute sum of the differences between two
+// bbox coordinates.
+function diffBbox(bbox, referenceBbox) {
+  return bbox.reduce((total, value, i) => {
+    return total + Math.abs(value - referenceBbox[i])
+  }, 0)
+}
+
+// Flip the coordinates of a bbox.
+function flipBbox(bbox) {
+  return [
+    bbox[1],
+    bbox[0],
+    bbox[3],
+    bbox[2]
+  ]
+}
+
+// Compare two bbox and determine whether the coordinates
+// in the first one are flipped.
+function isBboxFlipped(bbox, referenceBbox) {
+  const reversedBbox = flipBbox(bbox)
+
+  const diff = diffBbox(bbox, referenceBbox)
+  const reversedDiff = diffBbox(reversedBbox, referenceBbox)
+
+  return reversedDiff < diff
+}
+
+module.exports = {
+  diffBbox,
+  flipBbox,
+  isBboxFlipped
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@turf/bbox": "^6.0.1",
+    "@turf/flip": "^5.1.5",
     "chart.js": "^2.7.2",
     "compression": "^1.7.2",
     "cross-env": "^5.1.4",

--- a/pages/dataset.js
+++ b/pages/dataset.js
@@ -169,7 +169,7 @@ class DatasetPage extends React.Component {
                       <Header metadata={metadata} />
                     </Box>
                     <Box title={t('blocks.downloads')}>
-                      <Downloads distributions={dataset.distributions} />
+                      <Downloads distributions={dataset.distributions} extent={metadata.spatialExtent} />
                     </Box>
                     {datagouvPublication && (
                       <Box title={t('blocks.discussions')}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -150,6 +150,20 @@
     "@turf/helpers" "6.x"
     "@turf/meta" "6.x"
 
+"@turf/clone@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/clone/-/clone-5.1.5.tgz#253e8d35477181976e33adfab50a0f02a7f0e367"
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+
+"@turf/flip@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/flip/-/flip-5.1.5.tgz#436f643a722f0ca53b9fce638e4693db3608a68a"
+  dependencies:
+    "@turf/clone" "^5.1.5"
+    "@turf/helpers" "^5.1.5"
+    "@turf/meta" "^5.1.5"
+
 "@turf/helpers@4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-4.7.3.tgz#bc312ac43cab3c532a483151c4c382c5649429e9"
@@ -157,6 +171,10 @@
 "@turf/helpers@6.x":
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.1.3.tgz#0001a5c4a3bff25b4bbbc64f8713a383c9ab9e94"
+
+"@turf/helpers@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-5.1.5.tgz#153405227ab933d004a5bb9641a9ed999fcbe0cf"
 
 "@turf/meta@6.x":
   version "6.0.1"
@@ -167,6 +185,12 @@
 "@turf/meta@^4.7.3":
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-4.7.4.tgz#6de2f1e9890b8f64b669e4b47c09b20893063977"
+
+"@turf/meta@^5.1.5":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-5.2.0.tgz#3b1ad485ee0c3b0b1775132a32c384d53e4ba53d"
+  dependencies:
+    "@turf/helpers" "^5.1.5"
 
 "@types/node@*":
   version "8.0.57"


### PR DESCRIPTION
Pass producer-specified spatial extent down to the preview components to compare with the computed bounding box.