### PR TITLE
Highlight source features in map preview

### DIFF
--- a/components/centered-map/feature.js
+++ b/components/centered-map/feature.js
@@ -2,11 +2,11 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {translate} from 'react-i18next'
 
-const Feature = ({feature, otherFeaturesCount, t}) => (
+const Feature = ({properties, otherFeaturesCount, t}) => (
   <div>
     <ul>
-      {Object.keys(feature.properties).map(key =>
-        <li key={key}><b>{key} :</b> {feature.properties[key]}</li>
+      {Object.keys(properties).map(key =>
+        <li key={key}><b>{key} :</b> {properties[key]}</li>
       )}
     </ul>
 
@@ -47,9 +47,7 @@ const Feature = ({feature, otherFeaturesCount, t}) => (
 )
 
 Feature.propTypes = {
-  feature: PropTypes.shape({
-    properties: PropTypes.object.isRequired
-  }).isRequired,
+  properties: PropTypes.object.isRequired,
   otherFeaturesCount: PropTypes.number.isRequired,
 
   t: PropTypes.func.isRequired

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "isomorphic-unfetch": "^2.0.0",
     "lodash": "^4.17.10",
     "lodash-es": "^4.17.10",
-    "mapbox-gl": "^0.45.0-beta.1",
+    "mapbox-gl": "^0.45.0",
     "marked": "^0.3.19",
     "moment": "^2.22.1",
     "next": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5501,9 +5501,9 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-mapbox-gl@^0.45.0-beta.1:
-  version "0.45.0-beta.1"
-  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-0.45.0-beta.1.tgz#af196dcbf42a5deab8cc396d0a205ef87fd07753"
+mapbox-gl@^0.45.0:
+  version "0.45.0"
+  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-0.45.0.tgz#af71cc824f0d7e51ccd5c505eaae411bc0910ccd"
   dependencies:
     "@mapbox/gl-matrix" "^0.0.1"
     "@mapbox/jsonlint-lines-primitives" "^2.0.1"


### PR DESCRIPTION
Remove the opacity on polygon hover so the overlapping features are not visible.

It will be removed when https://github.com/w8r/martinez/issues/51 is fixed, so we can use @turf/union on the matching features and only render one feature.

---

See https://geodatagouv-pr-622.herokuapp.com/embed/datasets/7b15e5ff55087e7b75dba7c696fee85f6a85efc2/resources/wfs:5a2e9c73f43c6a15cb04f897/hdf_draaf:l_part_sau_2015_cantons_s_r32?lang=fr