### PR TITLE
Add webgl map fallback

### DIFF
--- a/__tests__/lib/browser/webgl.js
+++ b/__tests__/lib/browser/webgl.js
@@ -1,0 +1,7 @@
+import {isWebglSupported} from '../../../lib/browser/webgl'
+
+describe('isWebglSupported', () => {
+  it('should be false in test environment', () => {
+    expect(isWebglSupported()).toBe(false)
+  })
+})

--- a/components/centered-map/error-message.js
+++ b/components/centered-map/error-message.js
@@ -2,9 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import ErrorIcon from 'react-icons/lib/fa/times-circle'
 
-const ErrorMessage = ({children}) => (
+const ErrorMessage = ({small, children}) => (
   <div className='container'>
-    <div className='icon'>
+    <div className={`icon ${small ? 'small' : ''}`}>
       <ErrorIcon />
     </div>
 
@@ -32,6 +32,10 @@ const ErrorMessage = ({children}) => (
         color: $red;
       }
 
+      .small {
+        font-size: 54px;
+      }
+
       .text {
         color: $red;
         font-weight: bold;
@@ -42,7 +46,12 @@ const ErrorMessage = ({children}) => (
 )
 
 ErrorMessage.propTypes = {
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  small: PropTypes.bool
+}
+
+ErrorMessage.defaultProps = {
+  small: false
 }
 
 export default ErrorMessage

--- a/components/centered-map/loader.js
+++ b/components/centered-map/loader.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const Loader = ({children}) => (
+const Loader = ({small, children}) => (
   <div className='container'>
-    <div className='grid'>
+    <div className={`grid ${small ? 'small' : ''}`}>
       <div className='cube cube1' />
       <div className='cube cube2' />
       <div className='cube cube3' />
@@ -54,6 +54,17 @@ const Loader = ({children}) => (
         border-radius: 50%;
       }
 
+      .small {
+        width: 54px;
+        height: 54px;
+
+        .cube {
+          width: 14px;
+          height: 14px;
+          margin: 2px;
+        }
+      }
+
       .cube1 {
         animation-delay: 0.2s;
       }
@@ -95,7 +106,12 @@ const Loader = ({children}) => (
 )
 
 Loader.propTypes = {
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  small: PropTypes.bool
+}
+
+Loader.defaultProps = {
+  small: false
 }
 
 export default Loader

--- a/components/centered-map/map.js
+++ b/components/centered-map/map.js
@@ -1,0 +1,285 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import mapboxgl from 'mapbox-gl'
+import bbox from '@turf/bbox'
+import flip from '@turf/flip'
+
+import mapStyle from 'mapbox-gl/dist/mapbox-gl.css'
+
+import {isBboxFlipped, flipBbox} from '../../lib/geo/bbox'
+
+import Feature from './feature'
+
+const UNIQUE_FEATURE_ID = '$GDV_UNIQUE_FEATURE_ID$'
+
+class CenteredMap extends React.Component {
+  static propTypes = {
+    data: PropTypes.object.isRequired,
+    extent: PropTypes.object,
+    frozen: PropTypes.bool
+  }
+
+  static defaultProps = {
+    extent: null,
+    frozen: false
+  }
+
+  state = {
+    highlight: null
+  }
+
+  constructor(props) {
+    super(props)
+
+    this.bbox = bbox(props.data)
+    if (props.extent) {
+      if (isBboxFlipped(this.bbox, bbox(props.extent))) {
+        // Even though we should never mutate a component’s props,
+        // flipped coordinates should also never appear.
+        // We’re mutating the `data` prop here (and it is faster).
+
+        flip(props.data, {mutate: true})
+        this.bbox = flipBbox(this.bbox)
+      }
+    }
+
+    this.handlers = []
+
+    if (!props.frozen) {
+      if (props.data.features) {
+        props.data.features.forEach((feature, index) => {
+          feature.properties[UNIQUE_FEATURE_ID] = index
+        })
+      }
+
+      for (const layer of ['point', 'polygon-fill', 'line']) {
+        this.handlers.push({
+          event: 'mousemove',
+          layer,
+          handler: this.onMouseMove.bind(this, layer)
+        }, {
+          event: 'mouseleave',
+          layer,
+          handler: this.onMouseLeave.bind(this, layer)
+        })
+      }
+    }
+  }
+
+  componentDidMount() {
+    const {frozen} = this.props
+
+    this.map = new mapboxgl.Map({
+      container: this.mapContainer,
+      style: 'https://openmaptiles.geo.data.gouv.fr/styles/osm-bright/style.json',
+      interactive: !frozen
+    })
+
+    this.map.once('load', this.onLoad)
+
+    this.map.fitBounds(this.bbox, {
+      padding: 30,
+      linear: true,
+      duration: 0
+    })
+
+    for (const {event, layer, handler} of this.handlers) {
+      this.map.on(event, layer, handler)
+    }
+  }
+
+  componentWillUnmount() {
+    const {map} = this
+
+    for (const {event, layer, handler} of this.handlers) {
+      map.off(event, layer, handler)
+    }
+  }
+
+  onLoad = () => {
+    const {map} = this
+    const {data} = this.props
+
+    map.addSource('data', {
+      type: 'geojson',
+      data
+    })
+
+    map.addSource('hover', {
+      type: 'geojson',
+      data: {
+        type: 'FeatureCollection',
+        features: []
+      }
+    })
+
+    map.addLayer({
+      id: 'point',
+      type: 'circle',
+      source: 'data',
+      paint: {
+        'circle-radius': 5,
+        'circle-color': '#3099df',
+        'circle-opacity': 0.6
+      },
+      filter: ['==', '$type', 'Point']
+    })
+
+    map.addLayer({
+      id: 'point-hover',
+      type: 'circle',
+      source: 'hover',
+      paint: {
+        'circle-radius': 5,
+        'circle-color': '#2c3e50',
+        'circle-opacity': 0.8
+      },
+      filter: ['==', '$type', 'Point']
+    })
+
+    map.addLayer({
+      id: 'polygon-fill',
+      type: 'fill',
+      source: 'data',
+      paint: {
+        'fill-color': '#3099df',
+        'fill-opacity': 0.3
+      },
+      filter: ['==', '$type', 'Polygon']
+    })
+
+    map.addLayer({
+      id: 'polygon-fill-hover',
+      type: 'fill',
+      source: 'hover',
+      paint: {
+        'fill-color': '#9ab0d1'
+        // We’re not setting an opacity here.
+        // There will be overlapping features due to how vector tiles work.
+      },
+      filter: ['==', '$type', 'Polygon']
+    })
+
+    map.addLayer({
+      id: 'polygon-outline',
+      type: 'line',
+      source: 'data',
+      paint: {
+        'line-color': '#4790E5',
+        'line-width': 2
+      },
+      filter: ['==', '$type', 'Polygon']
+    })
+
+    map.addLayer({
+      id: 'line',
+      type: 'line',
+      source: 'data',
+      paint: {
+        'line-color': '#3099df',
+        'line-width': 5,
+        'line-opacity': 0.8
+      },
+      filter: ['==', '$type', 'LineString']
+    })
+
+    map.addLayer({
+      id: 'line-hover',
+      type: 'line',
+      source: 'hover',
+      paint: {
+        'line-color': '#2c3e50',
+        'line-width': 5,
+        'line-opacity': 0.8
+      },
+      filter: ['==', '$type', 'LineString']
+    })
+  }
+
+  onMouseMove = (layer, event) => {
+    const {map} = this
+    const canvas = map.getCanvas()
+    canvas.style.cursor = 'pointer'
+
+    const [feature] = event.features
+
+    const sourceFeatures = map.querySourceFeatures('data', {
+      filter: [
+        '==', UNIQUE_FEATURE_ID, feature.properties[UNIQUE_FEATURE_ID]
+      ]
+    })
+
+    // Eventually, we’ll have to @turf/union the sourceFeatures
+    // when https://github.com/w8r/martinez/issues/51 is fixed.
+
+    map.getSource('hover').setData({
+      type: 'FeatureCollection',
+      features: sourceFeatures
+    })
+
+    const properties = {...feature.properties}
+    delete properties[UNIQUE_FEATURE_ID]
+
+    this.setState({
+      highlight: {
+        properties,
+        count: event.features.length
+      }
+    })
+  }
+
+  onMouseLeave = () => {
+    const {map} = this
+    const canvas = map.getCanvas()
+    canvas.style.cursor = ''
+
+    map.getSource('hover').setData({
+      type: 'FeatureCollection',
+      features: []
+    })
+
+    this.setState({
+      highlight: null
+    })
+  }
+
+  render() {
+    const {highlight} = this.state
+
+    return (
+      <div className='container'>
+        <div ref={el => {
+          this.mapContainer = el
+        }} className='container' />
+
+        {highlight && (
+          <div className='info'>
+            <Feature properties={highlight.properties} otherFeaturesCount={highlight.count - 1} />
+          </div>
+        )}
+
+        <style
+          dangerouslySetInnerHTML={{__html: mapStyle}} // eslint-disable-line react/no-danger
+        />
+        <style jsx>{`
+          .container {
+            position: relative;
+            height: 100%;
+            width: 100%;
+          }
+
+          .info {
+            position: absolute;
+            pointer-events: none;
+            top: 10px;
+            left: 10px;
+            max-width: 40%;
+            overflow: hidden;
+          }
+        `}</style>
+      </div>
+    )
+  }
+}
+
+export default CenteredMap

--- a/components/dataset/downloads/preview.js
+++ b/components/dataset/downloads/preview.js
@@ -11,11 +11,7 @@ import {_get} from '../../../lib/fetch'
 import Modal from '../../modal'
 import Button from '../../button'
 import ErrorWrapper from '../../error-wrapper'
-
-const CenteredMap = dynamic(import('../../centered-map'), {
-  ssr: false,
-  loading: translate()(({t}) => t('loading'))
-})
+import CenteredMap from '../../centered-map'
 
 const PreviewTable = dynamic(import('./preview-table'), {
   ssr: false,

--- a/components/dataset/spatial-extent.js
+++ b/components/dataset/spatial-extent.js
@@ -1,12 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import dynamic from 'next/dynamic'
-import {translate} from 'react-i18next'
 
-const CenteredMap = dynamic(import('../centered-map'), {
-  ssr: false,
-  loading: translate()(({t}) => t('loading'))
-})
+import CenteredMap from '../centered-map'
 
 const SpatialExtent = ({extent}) => {
   const data = {
@@ -17,7 +12,7 @@ const SpatialExtent = ({extent}) => {
   return (
     <div>
       <div className='map'>
-        <CenteredMap data={data} frozen />
+        <CenteredMap small data={data} frozen />
       </div>
 
       <style jsx>{`

--- a/lib/browser/webgl.js
+++ b/lib/browser/webgl.js
@@ -1,0 +1,14 @@
+// eslint-disable-next-line import/prefer-default-export
+export function isWebglSupported() {
+  try {
+    const canvas = document.createElement('canvas')
+
+    return Boolean(
+      window.WebGLRenderingContext && (
+        canvas.getContext('webgl') || canvas.getContext('experimental-webgl')
+      )
+    )
+  } catch (e) {
+    return false
+  }
+}

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -70,6 +70,10 @@
   },
 
   "map": {
+    "loading": "Loading the map",
+    "errors": {
+      "noWebgl": "We couldn’t display this map because your browser doesn’t support WebGL"
+    },
     "additionalFeature": "One more feature…",
     "additionalFeature_plural": "{{ count }} more features…"
   },

--- a/locales/en/preview.json
+++ b/locales/en/preview.json
@@ -5,8 +5,7 @@
       "init": "Starting download",
       "progress": "Downloading: {{ bytes }}",
       "progressWithTotal": "Downloading: {{ bytes }} / {{ total }}"
-    },
-    "component": "Loading the map"
+    }
   },
 
   "error": {

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -70,6 +70,10 @@
   },
 
   "map": {
+    "loading": "Chargement de la carte",
+    "errors": {
+      "noWebgl": "Nous ne pouvons pas afficher cette carte car votre navigateur ne supporte pas WebGL"
+    },
     "additionalFeature": "Un objet de plus…",
     "additionalFeature_plural": "{{ count }} objets de plus…"
   },

--- a/locales/fr/preview.json
+++ b/locales/fr/preview.json
@@ -5,8 +5,7 @@
       "init": "Initialisation du téléchargement",
       "progress": "Téléchargement en cours : {{ bytes }}",
       "progressWithTotal": "Téléchargement en cours : {{ bytes }} / {{ total }}"
-    },
-    "component": "Chargement de la carte"
+    }
   },
 
   "error": {

--- a/pages/embed/preview.js
+++ b/pages/embed/preview.js
@@ -1,8 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import getConfig from 'next/config'
-import dynamic from 'next/dynamic'
-import {translate} from 'react-i18next'
 import bytes from 'bytes'
 
 import {_get} from '../../lib/fetch'
@@ -11,20 +9,13 @@ import {generateDistributionId, generateDistributionInfo} from '../../lib/distri
 
 import attachI18n from '../../components/hoc/attach-i18n'
 
-import Loader from '../../components/preview/loader'
-import ErrorMessage from '../../components/preview/error'
+import CenteredMap from '../../components/centered-map'
+import Loader from '../../components/centered-map/loader'
+import ErrorMessage from '../../components/centered-map/error-message'
 
 const {publicRuntimeConfig: {
   GEODATA_API_URL
 }} = getConfig()
-
-const CenteredMap = dynamic(import('../../components/centered-map'), {
-  loading: translate('preview')(({t}) => (
-    <Loader>
-      {t('loading.component')}
-    </Loader>
-  ))
-})
 
 class PreviewPage extends React.Component {
   static propTypes = {


### PR DESCRIPTION
Add wrapper around the map component to display the same loader and
error messages that are displayed in the preview embed.  More work needs
to be done to completely reuse the same components. Will be done in a
future PR.

Fix #627.