### PR TITLE
Change the map’s language when the language changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lodash": "^4.17.10",
     "lodash-es": "^4.17.10",
     "mapbox-gl": "^0.47.0",
+    "mapbox-omt-lang": "^1.1.0",
     "marked": "^0.5.0",
     "moment": "^2.22.2",
     "next": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6579,6 +6579,11 @@ mapbox-gl@^0.47.0:
     tinyqueue "^1.1.0"
     vt-pbf "^3.0.1"
 
+mapbox-omt-lang@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mapbox-omt-lang/-/mapbox-omt-lang-1.1.0.tgz#6a4beb3ec1dd3ca62f6efd7425bfe862d218994e"
+  integrity sha512-FpqD/Yq8pyEtCcSOApQyJCEabGoFxVqeFQ8gSpEXvD9DA96SLjvyS3vtI2pk4p++EkBIrM8SwqLbnO2eVYd2Hg==
+
 marked@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.5.1.tgz#062f43b88b02ee80901e8e8d8e6a620ddb3aa752"


### PR DESCRIPTION
Example: https://geodatagouv-pr-644.herokuapp.com/en/datasets/5063480c9190df50f3fc8a6b7838e19a19ddfeaf

This uses https://github.com/tusbar/mapbox-omt-lang.

---

https://geodatagouv-pr-644.herokuapp.com/embed/datasets/7b15e5ff55087e7b75dba7c696fee85f6a85efc2/resources/wfs:5a2e9c73f43c6a15cb04f897/hdf_draaf:l_part_sau_2015_cantons_s_r32?lang=en

versus

https://geodatagouv-pr-644.herokuapp.com/embed/datasets/7b15e5ff55087e7b75dba7c696fee85f6a85efc2/resources/wfs:5a2e9c73f43c6a15cb04f897/hdf_draaf:l_part_sau_2015_cantons_s_r32?lang=fr