### PR TITLE
Start map feature ids at 1

### DIFF
--- a/components/centered-map/enhance-map-data.js
+++ b/components/centered-map/enhance-map-data.js
@@ -47,7 +47,7 @@ export default Map => hoist(class extends React.PureComponent {
 
         transformedData.features = transformedData.features.map((feature, id) => ({
           ...feature,
-          id
+          id: id + 1
         }))
       }
     }


### PR DESCRIPTION
Starting with 0 seems to break mapbox-gl, resulting in an undefined id.
This fixes the highlight on the first feature of a dataset.

See https://geo.data.gouv.fr/en/datasets/6d0dfdf2ccb4c6f3fea807d3764b9fe49eb263f7