### PR TITLE
Fix publication pages

### DIFF
--- a/__tests__/components/__snapshots__/link.js.snap
+++ b/__tests__/components/__snapshots__/link.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Link /> should render as french 1`] = `
+<a
+  href="/fr/foo"
+  onClick={[Function]}
+>
+  Go somewhere
+</a>
+`;
+
+exports[`<Link /> should render the as property 1`] = `
+<a
+  href="/de/bar"
+  onClick={[Function]}
+>
+  Go somewhere
+</a>
+`;
+
+exports[`<Link /> should use the default language 1`] = `
+<a
+  href="/ru/foo"
+  onClick={[Function]}
+>
+  Go somewhere
+</a>
+`;

--- a/__tests__/components/link.js
+++ b/__tests__/components/link.js
@@ -1,0 +1,62 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import i18n from 'i18next'
+import {I18nextProvider} from 'react-i18next'
+
+import Link from '../../components/link'
+
+const i18next = i18n.init({ // eslint-disable-line import/no-named-as-default-member
+  load: 'languageOnly'
+})
+
+describe('<Link />', () => {
+  it('should render as french', () => {
+    const inst = i18next.cloneInstance()
+    inst.changeLanguage('fr')
+
+    const tree = renderer
+      .create(
+        <I18nextProvider i18n={inst}>
+          <Link href='/foo'>
+            <a>Go somewhere</a>
+          </Link>
+        </I18nextProvider>
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('should render the as property', () => {
+    const inst = i18next.cloneInstance()
+    inst.changeLanguage('de')
+
+    const tree = renderer
+      .create(
+        <I18nextProvider i18n={inst}>
+          <Link href='/foo' as='/bar'>
+            <a>Go somewhere</a>
+          </Link>
+        </I18nextProvider>
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('should use the default language', () => {
+    const inst = i18next.cloneInstance()
+
+    const tree = renderer
+      .create(
+        <I18nextProvider initialLanguage='ru' i18n={inst}>
+          <Link href='/foo'>
+            <a>Go somewhere</a>
+          </Link>
+        </I18nextProvider>
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/components/hoc/attach-session.js
+++ b/components/hoc/attach-session.js
@@ -4,38 +4,15 @@ import hoist from 'hoist-non-react-statics'
 
 import {getSession, clearSession} from '../../lib/session'
 
+import SessionContext from '../../contexts/session-context'
+
 export default Page => {
   const Extended = hoist(class extends React.Component {
     static propTypes = {
       ssr: PropTypes.bool.isRequired
     }
 
-    static childContextTypes = {
-      session: PropTypes.shape({
-        auth: PropTypes.bool,
-        user: PropTypes.shape({
-          id: PropTypes.string.isRequired,
-          first_name: PropTypes.string.isRequired,
-          last_name: PropTypes.string.isRequired,
-          avatar_thumbnail: PropTypes.string.isRequired
-        }),
-        clear: PropTypes.func.isRequired
-      })
-    }
-
     state = {}
-
-    getChildContext() {
-      const {session} = this.state
-
-      return {
-        session: session ? {
-          auth: session.auth,
-          user: session.user,
-          clear: clearSession
-        } : null
-      }
-    }
 
     async componentDidMount() {
       const {ssr} = this.props
@@ -45,13 +22,21 @@ export default Page => {
       })
 
       this.setState({
-        session
+        session: session ? {
+          auth: session.auth,
+          user: session.user,
+          clear: clearSession
+        } : null
       })
     }
 
     render() {
+      const {session} = this.state
+
       return (
-        <Page {...this.props} />
+        <SessionContext.Provider value={session}>
+          <Page {...this.props} />
+        </SessionContext.Provider>
       )
     }
   }, Page)

--- a/components/hoc/with-session.js
+++ b/components/hoc/with-session.js
@@ -1,25 +1,16 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import hoist from 'hoist-non-react-statics'
 
+import SessionContext from '../../contexts/session-context'
+
 export default Component => hoist(class extends React.Component {
-  static contextTypes = {
-    session: PropTypes.shape({
-      user: PropTypes.shape({
-        id: PropTypes.string.isRequired,
-        first_name: PropTypes.string.isRequired,
-        last_name: PropTypes.string.isRequired,
-        avatar_thumbnail: PropTypes.string.isRequired
-      }),
-      clear: PropTypes.func.isRequired
-    })
-  }
-
   render() {
-    const {session} = this.context
-
     return (
-      <Component session={session} {...this.props} />
+      <SessionContext.Consumer>
+        {session => (
+          <Component session={session} {...this.props} />
+        )}
+      </SessionContext.Consumer>
     )
   }
 }, Component)

--- a/components/link.js
+++ b/components/link.js
@@ -2,8 +2,18 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import NextLink from 'next/link'
+import {translate} from 'react-i18next'
 
-const Link = ({href, as, ...props}, {i18n: {language}}) => {
+const Link = ({
+  href,
+  as,
+  i18n: {language},
+
+  tReady, // Destructured so that it’s not included in ...props
+  t, // Destructured so that it’s not included in ...props
+
+  ...props
+}) => {
   const newAs = as ? `/${language}${as}` : `/${language}${href}`
 
   return (
@@ -13,17 +23,14 @@ const Link = ({href, as, ...props}, {i18n: {language}}) => {
 
 Link.propTypes = {
   href: PropTypes.string.isRequired,
-  as: PropTypes.string
+  as: PropTypes.string,
+  i18n: PropTypes.shape({
+    language: PropTypes.string.isRequired
+  }).isRequired
 }
 
 Link.defaultProps = {
   as: null
 }
 
-Link.contextTypes = {
-  i18n: PropTypes.shape({
-    language: PropTypes.string.isRequired
-  }).isRequired
-}
-
-export default Link
+export default translate()(Link)

--- a/components/require-auth.js
+++ b/components/require-auth.js
@@ -58,7 +58,7 @@ class RequireAuth extends React.Component {
             <Button href={loginUrl}>
               {t('auth.login')}
             </Button>
-            <Button href='https://id.data.gouv.fr/register/'>
+            <Button href='https://www.data.gouv.fr/register'>
               {t('auth.register')}
             </Button>
           </div>

--- a/components/require-auth.js
+++ b/components/require-auth.js
@@ -73,7 +73,7 @@ class RequireAuth extends React.Component {
             }
 
             .buttons {
-              :global(button) {
+              :global(a) {
                 margin-right: 5px;
               }
             }

--- a/contexts/session-context.js
+++ b/contexts/session-context.js
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export default React.createContext(null)

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,10 +1,13 @@
 import React from 'react'
 import App, {Container} from 'next/app'
+import {flowRight} from 'lodash'
 import Head from 'next/head'
 import getConfig from 'next/config'
 
 import {languages} from '../lib/i18n'
-import attachI18next from '../components/hoc/attach-i18n'
+
+import attachI18n from '../components/hoc/attach-i18n'
+import attachSession from '../components/hoc/attach-session'
 
 const {publicRuntimeConfig: {
   PUBLIC_URL,
@@ -88,4 +91,7 @@ class MyApp extends App {
   }
 }
 
-export default attachI18next()(MyApp)
+export default flowRight(
+  attachI18n(),
+  attachSession
+)(MyApp)

--- a/pages/catalog.js
+++ b/pages/catalog.js
@@ -7,7 +7,6 @@ import {_get, _post} from '../lib/fetch'
 import {isObsolete} from '../lib/catalog'
 
 import attachI18n from '../components/hoc/attach-i18n'
-import attachSession from '../components/hoc/attach-session'
 import withErrors from '../components/hoc/with-errors'
 
 import Page from '../components/page'
@@ -122,6 +121,5 @@ class CatalogPage extends React.Component {
 
 export default flowRight(
   attachI18n('catalogs'),
-  attachSession,
   withErrors
 )(CatalogPage)

--- a/pages/catalogs.js
+++ b/pages/catalogs.js
@@ -7,7 +7,6 @@ import {_get} from '../lib/fetch'
 import {sortByScore} from '../lib/catalog'
 
 import attachI18n from '../components/hoc/attach-i18n'
-import attachSession from '../components/hoc/attach-session'
 import withErrors from '../components/hoc/with-errors'
 
 import Page from '../components/page'
@@ -97,6 +96,5 @@ class CatalogsPage extends React.Component {
 
 export default flowRight(
   attachI18n('catalogs'),
-  attachSession,
   withErrors
 )(CatalogsPage)

--- a/pages/dataset.js
+++ b/pages/dataset.js
@@ -6,7 +6,6 @@ import {uniqWith, isEqual, flowRight} from 'lodash'
 import {_get} from '../lib/fetch'
 
 import attachI18n from '../components/hoc/attach-i18n'
-import attachSession from '../components/hoc/attach-session'
 import withErrors from '../components/hoc/with-errors'
 
 import Page from '../components/page'
@@ -282,6 +281,5 @@ class DatasetPage extends React.Component {
 
 export default flowRight(
   attachI18n('dataset'),
-  attachSession,
   withErrors
 )(DatasetPage)

--- a/pages/doc.js
+++ b/pages/doc.js
@@ -1,10 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {flowRight} from 'lodash'
 import FaBook from 'react-icons/lib/fa/book'
 
 import attachI18n from '../components/hoc/attach-i18n'
-import attachSession from '../components/hoc/attach-session'
 
 import Page from '../components/page'
 import Meta from '../components/meta'
@@ -52,7 +50,4 @@ class DocumentationPage extends React.Component {
   }
 }
 
-export default flowRight(
-  attachI18n(),
-  attachSession
-)(DocumentationPage)
+export default attachI18n()(DocumentationPage)

--- a/pages/doc/link-proxy.js
+++ b/pages/doc/link-proxy.js
@@ -1,9 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {flowRight} from 'lodash'
 
 import attachI18n from '../../components/hoc/attach-i18n'
-import attachSession from '../../components/hoc/attach-session'
 
 import Page from '../../components/page'
 import Meta from '../../components/meta'
@@ -97,7 +95,4 @@ LinkProxyPage.propTypes = {
   tReady: PropTypes.bool.isRequired
 }
 
-export default flowRight(
-  attachI18n(),
-  attachSession
-)(LinkProxyPage)
+export default attachI18n()(LinkProxyPage)

--- a/pages/doc/publish-your-data.js
+++ b/pages/doc/publish-your-data.js
@@ -1,9 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {flowRight} from 'lodash'
 
 import attachI18n from '../../components/hoc/attach-i18n'
-import attachSession from '../../components/hoc/attach-session'
 
 import Page from '../../components/page'
 import Meta from '../../components/meta'
@@ -229,7 +227,4 @@ PublishYourDataPage.propTypes = {
   tReady: PropTypes.bool.isRequired
 }
 
-export default flowRight(
-  attachI18n(),
-  attachSession
-)(PublishYourDataPage)
+export default attachI18n()(PublishYourDataPage)

--- a/pages/events.js
+++ b/pages/events.js
@@ -1,9 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {flowRight} from 'lodash'
 
 import attachI18n from '../components/hoc/attach-i18n'
-import attachSession from '../components/hoc/attach-session'
 
 import Page from '../components/page'
 import Meta from '../components/meta'
@@ -98,7 +96,4 @@ EventsPage.propTypes = {
   tReady: PropTypes.bool.isRequired
 }
 
-export default flowRight(
-  attachI18n('events'),
-  attachSession
-)(EventsPage)
+export default attachI18n('events')(EventsPage)

--- a/pages/harvest.js
+++ b/pages/harvest.js
@@ -6,7 +6,6 @@ import getConfig from 'next/config'
 import {_get} from '../lib/fetch'
 
 import attachI18n from '../components/hoc/attach-i18n'
-import attachSession from '../components/hoc/attach-session'
 import withErrors from '../components/hoc/with-errors'
 
 import Page from '../components/page'
@@ -98,6 +97,5 @@ class HarvestPage extends React.Component {
 
 export default flowRight(
   attachI18n('catalogs'),
-  attachSession,
   withErrors
 )(HarvestPage)

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,10 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {flowRight} from 'lodash'
 import getConfig from 'next/config'
 
 import attachI18n from '../components/hoc/attach-i18n'
-import attachSession from '../components/hoc/attach-session'
 
 import {_get} from '../lib/fetch'
 
@@ -58,7 +56,4 @@ class IndexPage extends React.Component {
   }
 }
 
-export default flowRight(
-  attachI18n('home'),
-  attachSession
-)(IndexPage)
+export default attachI18n('home')(IndexPage)

--- a/pages/legal.js
+++ b/pages/legal.js
@@ -1,9 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {flowRight} from 'lodash'
 
 import attachI18n from '../components/hoc/attach-i18n'
-import attachSession from '../components/hoc/attach-session'
 
 import Page from '../components/page'
 import Meta from '../components/meta'
@@ -63,7 +61,4 @@ LegalPage.propTypes = {
   tReady: PropTypes.bool.isRequired
 }
 
-export default flowRight(
-  attachI18n(),
-  attachSession
-)(LegalPage)
+export default attachI18n()(LegalPage)

--- a/pages/publication.js
+++ b/pages/publication.js
@@ -1,9 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {flowRight} from 'lodash'
 
 import attachI18n from '../components/hoc/attach-i18n'
-import attachSession from '../components/hoc/attach-session'
 
 import Page from '../components/page'
 import Meta from '../components/meta'
@@ -71,7 +69,4 @@ PublicationPage.propTypes = {
   tReady: PropTypes.bool.isRequired
 }
 
-export default flowRight(
-  attachI18n(),
-  attachSession
-)(PublicationPage)
+export default attachI18n()(PublicationPage)

--- a/pages/publication/datasets.js
+++ b/pages/publication/datasets.js
@@ -6,7 +6,6 @@ import getConfig from 'next/config'
 import {_get, _put} from '../../lib/fetch'
 
 import attachI18n from '../../components/hoc/attach-i18n'
-import attachSession from '../../components/hoc/attach-session'
 import withSession from '../../components/hoc/with-session'
 
 import Page from '../../components/page'
@@ -37,12 +36,18 @@ class DatasetsPublicationPage extends React.Component {
     session: null
   }
 
-  state = {}
-
   static getInitialProps({query}) {
     return {
       organizationId: query.oid
     }
+  }
+
+  state = {}
+
+  componentDidMount() {
+    this.setState({
+      datasetsPromise: this.fetchDatasets()
+    })
   }
 
   fetchDatasets = () => {
@@ -53,16 +58,6 @@ class DatasetsPublicationPage extends React.Component {
       _get(`${PUBLICATION_BASE_URL}/api/organizations/${organizationId}/datasets/not-published-yet`),
       _get(`${PUBLICATION_BASE_URL}/api/organizations/${organizationId}/datasets/published-by-others`)
     ])
-  }
-
-  UNSAFE_componentWillReceiveProps(props) {
-    const {session} = this.props
-
-    if (props.session && props.session.user && !session) {
-      this.setState({
-        datasetsPromise: this.fetchDatasets()
-      })
-    }
   }
 
   _getPublishDatasetsPromise = async datasets => {
@@ -128,6 +123,5 @@ class DatasetsPublicationPage extends React.Component {
 
 export default flowRight(
   attachI18n(),
-  attachSession,
   withSession
 )(DatasetsPublicationPage)

--- a/pages/publication/organization.js
+++ b/pages/publication/organization.js
@@ -6,7 +6,6 @@ import getConfig from 'next/config'
 import {_get, _put} from '../../lib/fetch'
 
 import attachI18n from '../../components/hoc/attach-i18n'
-import attachSession from '../../components/hoc/attach-session'
 import withSession from '../../components/hoc/with-session'
 
 import Page from '../../components/page'
@@ -49,22 +48,20 @@ class OrganizationPublicationPage extends React.Component {
 
   state = {}
 
+  componentDidMount() {
+    const {organizationId} = this.props
+
+    this.setState({
+      organizationPromise: this.fetchOrganization(),
+      catalogsPromise: _get(`${GEODATA_API_URL}/catalogs`),
+      metricsPromise: _get(`${PUBLICATION_BASE_URL}/api/organizations/${organizationId}/datasets/metrics`)
+    })
+  }
+
   fetchOrganization = () => {
     const {organizationId} = this.props
 
     return _get(`${PUBLICATION_BASE_URL}/api/organizations/${organizationId}`)
-  }
-
-  UNSAFE_componentWillReceiveProps(props) {
-    const {session} = this.props
-
-    if (props.session && props.session.user && !session) {
-      this.setState({
-        organizationPromise: this.fetchOrganization(),
-        catalogsPromise: _get(`${GEODATA_API_URL}/catalogs`),
-        metricsPromise: _get(`${PUBLICATION_BASE_URL}/api/organizations/${props.organizationId}/datasets/metrics`)
-      })
-    }
   }
 
   _getUpdateCatalogsPromise = async (organization, catalogs) => {
@@ -109,7 +106,7 @@ class OrganizationPublicationPage extends React.Component {
         <div className='dashboard'>
           <Box title='Catalogues source' color='blue'>
             <SourceCatalogs
-              promise={Promise.all([organizationPromise, catalogsPromise])}
+              promise={[organizationPromise, catalogsPromise]}
               removeCatalog={this.removeCatalog}
               addCatalog={this.addCatalog}
             />
@@ -121,7 +118,7 @@ class OrganizationPublicationPage extends React.Component {
           </Box>
           <Box title='Jeux de données' color='blue'>
             <DatasetMetrics
-              promise={Promise.all([organizationPromise, metricsPromise])}
+              promise={[organizationPromise, metricsPromise]}
             />
           </Box>
         </div>
@@ -180,6 +177,5 @@ class OrganizationPublicationPage extends React.Component {
 
 export default flowRight(
   attachI18n(),
-  attachSession,
   withSession
 )(OrganizationPublicationPage)

--- a/pages/publication/producers.js
+++ b/pages/publication/producers.js
@@ -6,7 +6,6 @@ import getConfig from 'next/config'
 import {_get, _post, _delete} from '../../lib/fetch'
 
 import attachI18n from '../../components/hoc/attach-i18n'
-import attachSession from '../../components/hoc/attach-session'
 import withSession from '../../components/hoc/with-session'
 
 import Page from '../../components/page'
@@ -37,29 +36,25 @@ class ProducersPublicationPage extends React.Component {
     session: null
   }
 
-  state = {}
-
   static getInitialProps({query}) {
     return {
       organizationId: query.oid
     }
   }
 
+  state = {}
+
+  componentDidMount() {
+    this.setState({
+      producersPromise: this.fetchProducers(),
+      organizationsPromise: _get(`${PUBLICATION_BASE_URL}/api/organizations`)
+    })
+  }
+
   fetchProducers = () => {
     const {organizationId} = this.props
 
     return _get(`${PUBLICATION_BASE_URL}/api/organizations/${organizationId}/producers`)
-  }
-
-  UNSAFE_componentWillReceiveProps(props) {
-    const {session} = this.props
-
-    if (props.session && props.session.user && !session) {
-      this.setState({
-        producersPromise: this.fetchProducers(),
-        organizationsPromise: _get(`${PUBLICATION_BASE_URL}/api/organizations`)
-      })
-    }
   }
 
   _getAssociateProducerPromise = async producer => {
@@ -106,7 +101,7 @@ class ProducersPublicationPage extends React.Component {
         <Breadcrumbs organization={organization} page='producers' />
         <Producers
           organization={organization}
-          promise={Promise.all([producersPromise, organizationsPromise])}
+          promise={[producersPromise, organizationsPromise]}
           associateProducer={this.associateProducer}
           dissociateProducer={this.dissociateProducer}
         />
@@ -139,6 +134,5 @@ class ProducersPublicationPage extends React.Component {
 
 export default flowRight(
   attachI18n(),
-  attachSession,
   withSession
 )(ProducersPublicationPage)

--- a/pages/search.js
+++ b/pages/search.js
@@ -8,7 +8,6 @@ import {_get} from '../lib/fetch'
 import {getFilters} from '../lib/query'
 
 import attachI18n from '../components/hoc/attach-i18n'
-import attachSession from '../components/hoc/attach-session'
 import withErrors from '../components/hoc/with-errors'
 
 import Page from '../components/page'
@@ -170,6 +169,5 @@ class SearchPage extends React.Component {
 
 export default flowRight(
   attachI18n(['search', 'dataset']),
-  attachSession,
   withErrors
 )(SearchPage)


### PR DESCRIPTION
- Use new React Context API for session context
- Use translate() HOC for custom `Link` component to stop using old context API (+ add tests)
- Move attachSession HOC to _app page
- Remove deprecated UNSAFE_* lifecycle methods
- Fix data.gouv.fr register link
- Fix some CSS