### PR TITLE
Do not allow a search to be sent if there is no value in the search field

### DIFF
--- a/components/search-input.js
+++ b/components/search-input.js
@@ -56,7 +56,7 @@ class SearchInput extends React.PureComponent {
     const {value} = this.state
 
     if (!value.trim()) {
-      return false;
+      return false
     }
 
     const query = {

--- a/components/search-input.js
+++ b/components/search-input.js
@@ -55,6 +55,10 @@ class SearchInput extends React.PureComponent {
     const {router, i18n, defaultQuery} = this.props
     const {value} = this.state
 
+    if (!value.trim()) {
+      return false;
+    }
+
     const query = {
       ...defaultQuery,
       ...router.query,


### PR DESCRIPTION
Hello,

The current behavior allows send if there no value in the search field.

I think that make sense ignore this behavior because if we want to see all datasets we can click on the link below called: `View all datasets`.